### PR TITLE
Refactor yGraph to use a single root doc

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,4 +1,6 @@
 // See https://kit.svelte.dev/docs/types#app
+import type { Koso } from "$lib/koso";
+
 // for information about these interfaces
 declare global {
   namespace App {
@@ -7,6 +9,10 @@ declare global {
     // interface PageData {}
     // interface PageState {}
     // interface Platform {}
+  }
+
+  interface Window {
+    koso: Koso;
   }
 }
 

--- a/frontend/src/lib/DagTable/row.svelte
+++ b/frontend/src/lib/DagTable/row.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type { User } from "$lib/auth";
   import type { Koso } from "$lib/koso";
-  import UserSelect from "$lib/user-select.svelte";
   import TaskStatusSelect from "$lib/task-status-select.svelte";
   import TaskStatus from "$lib/task-status.svelte";
+  import UserSelect from "$lib/user-select.svelte";
   import { cn } from "$lib/utils";
   import { A, Avatar, Dropdown, Input, Tooltip } from "flowbite-svelte";
   import { ChevronRight, GripVertical } from "lucide-svelte";

--- a/frontend/src/lib/DagTable/row.svelte
+++ b/frontend/src/lib/DagTable/row.svelte
@@ -148,7 +148,7 @@
         ghostOffset,
       );
     } else {
-      koso.addNode($dragged.name, ghostNode.parent().name, ghostOffset);
+      koso.linkNode($dragged.name, ghostNode.parent().name, ghostOffset);
     }
     $dragged = null;
     ghostNode = null;

--- a/frontend/src/lib/DagTable/row.svelte
+++ b/frontend/src/lib/DagTable/row.svelte
@@ -79,7 +79,7 @@
     if (editedTaskName === null) {
       return;
     }
-    koso.editTaskName(node.name, editedTaskName);
+    koso.setTaskName(node.name, editedTaskName);
     editedTaskName = null;
   }
 
@@ -467,7 +467,7 @@
     <Dropdown bind:open={statusSelectorOpen}>
       <TaskStatusSelect
         on:select={(event) => {
-          koso.editTaskStatus(task.id, event.detail);
+          koso.setTaskStatus(task.id, event.detail);
           statusSelectorOpen = false;
         }}
       />

--- a/frontend/src/lib/DagTable/state.ts
+++ b/frontend/src/lib/DagTable/state.ts
@@ -1,7 +1,8 @@
 import { derived, writable } from "svelte/store";
-import type { Node } from "../koso";
+import type { Node, Parents } from "../koso";
 
 export const nodes = writable<Node[]>([]);
+export const parents = writable<Parents>({});
 export const selected = writable<Node | null>(null);
 export const highlighted = writable<Node | null>(null);
 export const dropEffect = writable<"link" | "move" | "none">("none");

--- a/frontend/src/lib/DagTable/table.svelte
+++ b/frontend/src/lib/DagTable/table.svelte
@@ -70,7 +70,7 @@
 
   function addRoot() {
     if (!$user) throw new Error("Unauthenticated");
-    koso.insertNode("root", 0, $user);
+    koso.insertNode("root", 0, "Untitled", $user);
   }
 
   function addPeer() {
@@ -80,6 +80,7 @@
     const newNodeId = koso.insertNode(
       parent.name,
       koso.getOffset($selected) + 1,
+      "Untitled",
       $user,
     );
     $selected = parent.concat(newNodeId);
@@ -88,7 +89,7 @@
   function addChild() {
     if (!$selected) return;
     if (!$user) throw new Error("Unauthenticated");
-    const newNodeId = koso.insertNode($selected.name, 0, $user);
+    const newNodeId = koso.insertNode($selected.name, 0, "Untitled", $user);
     $selected = $selected.concat(newNodeId);
   }
 

--- a/frontend/src/lib/DagTable/table.svelte
+++ b/frontend/src/lib/DagTable/table.svelte
@@ -94,7 +94,7 @@
 
   function unlink() {
     if (!$selected) return;
-    koso.removeNode($selected);
+    koso.unlinkNode($selected);
     $selected = null;
   }
 

--- a/frontend/src/lib/DagTable/table.svelte
+++ b/frontend/src/lib/DagTable/table.svelte
@@ -5,9 +5,8 @@
   import { List, ListStart, ListTree, Trash, Unlink } from "lucide-svelte";
   import { setContext } from "svelte";
   import { flip } from "svelte/animate";
-  import { Node } from "../koso";
   import Row from "./row.svelte";
-  import { hidden, nodes, selected } from "./state";
+  import { hidden, nodes, parents, selected } from "./state";
   import { receive, send } from "./transition";
 
   export let koso: Koso;
@@ -15,8 +14,10 @@
   let rows: { [key: string]: HTMLDivElement } = {};
 
   $nodes = koso.toNodes();
+  $parents = koso.toParents();
   koso.observe(() => {
     $nodes = koso.toNodes();
+    $parents = koso.toParents();
   });
 
   document.onkeydown = (event: KeyboardEvent) => {
@@ -69,24 +70,19 @@
 
   function addRoot() {
     if (!$user) throw new Error("Unauthenticated");
-    koso.addRoot($user);
+    koso.insertNode("root", 0, $user);
   }
 
   function addPeer() {
     if (!$selected) return;
     if (!$user) throw new Error("Unauthenticated");
-    if ($selected.isRoot()) {
-      const newNodeId = koso.addRoot($user);
-      $selected = new Node([newNodeId]);
-    } else {
-      const parent = $selected.parent();
-      const newNodeId = koso.insertNode(
-        parent.name,
-        koso.getOffset($selected) + 1,
-        $user,
-      );
-      $selected = parent.concat(newNodeId);
-    }
+    const parent = $selected.parent();
+    const newNodeId = koso.insertNode(
+      parent.name,
+      koso.getOffset($selected) + 1,
+      $user,
+    );
+    $selected = parent.concat(newNodeId);
   }
 
   function addChild() {
@@ -98,20 +94,20 @@
 
   function unlink() {
     if (!$selected) return;
-    koso.removeNode($selected.name, $selected.parent().name);
+    koso.removeNode($selected);
     $selected = null;
   }
 
   function remove() {
     if (!$selected) return;
-    koso.deleteNode($selected.name);
+    koso.deleteNode($selected);
     $selected = null;
   }
 
   setContext<Koso>("koso", koso);
 </script>
 
-<div class="sticky top-4 z-50 flex gap-2 bg-white py-2">
+<div class="my-2 flex gap-2">
   {#if $selected}
     <Button size="xs" on:click={addPeer}>
       <List class="me-2 w-4" />Add Peer
@@ -119,7 +115,7 @@
     <Button size="xs" on:click={addChild}>
       <ListTree class="me-2 w-4" />Add Child
     </Button>
-    {#if $selected.isRoot()}
+    {#if $parents[$selected.name].length === 1}
       <Button size="xs" on:click={remove}>
         <Trash class="me-2 w-4" />Delete
       </Button>
@@ -136,9 +132,7 @@
 </div>
 
 <table class="w-full border">
-  <thead
-    class="sticky top-[4.4rem] z-50 bg-white text-left text-xs font-bold uppercase"
-  >
+  <thead class="text-left text-xs font-bold uppercase">
     <tr>
       <th class="w-32 border p-2">ID</th>
       <th class="border p-2">Name</th>

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -9,7 +9,7 @@ function addItem(
   name: string,
   children: string[],
 ) {
-  koso.upsert({
+  koso.#upsert({
     id,
     num,
     name,
@@ -138,7 +138,7 @@ describe("Koso tests", () => {
       addItem(koso, "id1", "1", "Task 1", []);
       addItem(koso, "id2", "2", "Task 2", []);
 
-      koso.addNode("id2", "id1", 0);
+      koso.linkNode("id2", "id1", 0);
 
       expect(koso.yGraph.toJSON()).toStrictEqual({
         id1: {
@@ -166,7 +166,7 @@ describe("Koso tests", () => {
       addItem(koso, "id1", "1", "Task 1", ["id2"]);
       addItem(koso, "id2", "2", "Task 2", []);
 
-      koso.removeNode("id2", "id1");
+      koso.unlinkNode("id2", "id1");
 
       expect(koso.yGraph.toJSON()).toStrictEqual({
         id1: {
@@ -195,7 +195,7 @@ describe("Koso tests", () => {
       addItem(koso, "id2", "2", "Task 2", []);
       addItem(koso, "id3", "3", "Task 3", []);
 
-      koso.addNode("id3", "id1", 1);
+      koso.linkNode("id3", "id1", 1);
 
       expect(koso.yGraph.toJSON()).toStrictEqual({
         id1: {
@@ -233,7 +233,7 @@ describe("Koso tests", () => {
       addItem(koso, "id2", "2", "Task 2", []);
       addItem(koso, "id3", "3", "Task 3", []);
 
-      koso.addNode("id3", "id1", 0);
+      koso.linkNode("id3", "id1", 0);
 
       expect(koso.yGraph.toJSON()).toStrictEqual({
         id1: {

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -27,29 +27,6 @@ describe("Koso tests", () => {
     koso.handleClientMessage(() => {});
   });
 
-  describe("getRoots", () => {
-    it("empty graph returns empty set", () => {
-      expect(koso.getRoots()).toStrictEqual(new Set([]));
-    });
-
-    it("graph with one task returns one root", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      expect(koso.getRoots()).toStrictEqual(new Set(["id1"]));
-    });
-
-    it("graph with two tasks and one root returns one root", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.getRoots()).toStrictEqual(new Set(["id1"]));
-    });
-
-    it("graph with two roots returns two roots", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.getRoots()).toStrictEqual(new Set(["id1", "id2"]));
-    });
-  });
-
   describe("getTask", () => {
     it("retrieves task 2", () => {
       addItem(koso, "id1", "1", "Task 1", ["id2"]);
@@ -61,6 +38,7 @@ describe("Koso tests", () => {
         children: [],
         reporter: "t@koso.app",
         assignee: null,
+        status: null,
       });
     });
 
@@ -126,6 +104,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -141,6 +120,7 @@ describe("Koso tests", () => {
           children: ["id2"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -149,6 +129,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -167,6 +148,7 @@ describe("Koso tests", () => {
           children: ["id2"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -175,6 +157,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -193,6 +176,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -201,6 +185,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -220,6 +205,7 @@ describe("Koso tests", () => {
           children: ["id2", "id3"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -228,6 +214,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id3: {
           id: "id3",
@@ -236,6 +223,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -255,6 +243,7 @@ describe("Koso tests", () => {
           children: ["id3", "id2"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -263,6 +252,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id3: {
           id: "id3",
@@ -271,6 +261,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -289,6 +280,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -297,6 +289,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -317,6 +310,7 @@ describe("Koso tests", () => {
           children: ["id2", "id3"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -325,6 +319,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id3: {
           id: "id3",
@@ -333,6 +328,7 @@ describe("Koso tests", () => {
           children: ["id4"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id4: {
           id: "id4",
@@ -341,6 +337,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -361,6 +358,7 @@ describe("Koso tests", () => {
           children: ["id2", "id4", "id3"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -369,6 +367,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id3: {
           id: "id3",
@@ -377,6 +376,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id4: {
           id: "id4",
@@ -385,6 +385,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -405,6 +406,7 @@ describe("Koso tests", () => {
           children: ["id2", "id4", "id3"],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id2: {
           id: "id2",
@@ -413,6 +415,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id3: {
           id: "id3",
@@ -421,6 +424,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
         id4: {
           id: "id4",
@@ -429,6 +433,7 @@ describe("Koso tests", () => {
           children: [],
           reporter: "t@koso.app",
           assignee: null,
+          status: null,
         },
       });
     });
@@ -458,6 +463,7 @@ describe("Koso tests", () => {
             children: ["idB", "id3", idMatching],
             reporter: "t@koso.app",
             assignee: null,
+            status: null,
           },
           idB: {
             id: "idB",
@@ -466,6 +472,7 @@ describe("Koso tests", () => {
             children: [],
             reporter: "t@koso.app",
             assignee: null,
+            status: null,
           },
           id3: {
             id: "id3",
@@ -474,6 +481,7 @@ describe("Koso tests", () => {
             children: [],
             reporter: "t@koso.app",
             assignee: null,
+            status: null,
           },
         }),
       );
@@ -487,8 +495,9 @@ describe("Koso tests", () => {
         num: "4",
         name: "Untitled",
         children: [],
-        assignee: null,
         reporter: "test@koso.app",
+        assignee: null,
+        status: null,
       });
     });
   });

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -1,38 +1,38 @@
+import * as encoding from "lib0/encoding";
 import { beforeEach, describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import type { User } from "./auth";
 import { Koso, Node } from "./koso";
 
-function addItem(
-  koso: Koso,
-  id: string,
-  num: string,
-  name: string,
-  children: string[],
-) {
-  koso.#upsert({
-    id,
-    num,
-    name,
-    children,
-    reporter: "t@koso.app",
-    assignee: null,
-    status: null,
-  });
-}
+const USER: User = {
+  email: "t@koso.app",
+  name: "Test User",
+  picture: "",
+  exp: 0,
+};
+
+const EMPTY_SYNC_RESPONSE = (() => {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, 0);
+  encoding.writeVarUint(encoder, 1);
+  encoding.writeVarUint8Array(encoder, Y.encodeStateAsUpdateV2(new Y.Doc()));
+  return encoding.toUint8Array(encoder);
+})();
 
 describe("Koso tests", () => {
   let koso: Koso;
   beforeEach(() => {
     koso = new Koso("project-id", new Y.Doc());
     koso.handleClientMessage(() => {});
+    koso.handleServerMessage(EMPTY_SYNC_RESPONSE);
   });
 
   describe("getTask", () => {
     it("retrieves task 2", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.getTask("id2")).toStrictEqual({
-        id: "id2",
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      expect(koso.getTask(id2)).toStrictEqual({
+        id: id2,
         num: "2",
         name: "Task 2",
         children: [],
@@ -43,62 +43,132 @@ describe("Koso tests", () => {
     });
 
     it("invalid task id throws an exception", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      addItem(koso, "id2", "2", "Task 2", []);
+      koso.insertNode("root", 0, "Task 1", USER);
+      koso.insertNode("root", 1, "Task 2", USER);
       expect(() => koso.getTask("id3")).toThrow();
     });
   });
 
   describe("getChildren", () => {
     it("retrieves task 1's children", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.getChildren("id1")).toStrictEqual(["id2"]);
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      expect(koso.getChildren(id1)).toStrictEqual([id2]);
     });
 
     it("retrieves empty list of children for leaf task", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.getChildren("id2")).toStrictEqual([]);
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      expect(koso.getChildren(id2)).toStrictEqual([]);
     });
 
     it("invalid task id throws an exception", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      addItem(koso, "id2", "2", "Task 2", []);
+      koso.insertNode("root", 0, "Task 1", USER);
+      koso.insertNode("root", 1, "Task 2", USER);
       expect(() => koso.getChildren("id3")).toThrow();
     });
   });
 
+  describe("getOffset", () => {
+    it("offset of root is 0", () => {
+      expect(koso.getOffset(new Node([]))).toBe(0);
+    });
+
+    it("offset of first node is 0", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      koso.insertNode("root", 1, "Task 2", USER);
+      expect(koso.getOffset(new Node([id1]))).toBe(0);
+    });
+
+    it("offset of first node is 0", () => {
+      koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      expect(koso.getOffset(new Node([id2]))).toBe(1);
+    });
+  });
+
   describe("toNodes", () => {
-    it("empty graph renders successfully", () => {
+    it("empty doc has no nodes", () => {
       expect(koso.toNodes()).toStrictEqual([]);
     });
 
-    it("graph with one root node renders successfully", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      expect(koso.toNodes()).toStrictEqual([new Node(["id1"])]);
+    it("doc with one task has one node", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      expect(koso.toNodes()).toStrictEqual([new Node([id1])]);
     });
 
-    it("populated graph renders successfully", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
+    it("doc with two tasks has two nodes", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      expect(koso.toNodes()).toStrictEqual([new Node([id1]), new Node([id2])]);
+    });
+
+    it("doc with a multi-linked task has three nodes", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      koso.linkNode(id2, id1, 0);
       expect(koso.toNodes()).toStrictEqual([
-        new Node(["id1"]),
-        new Node(["id1", "id2"]),
+        new Node([id1]),
+        new Node([id1, id2]),
+        new Node([id2]),
       ]);
+    });
+  });
+
+  describe("toParents", () => {
+    it("empty doc has no parents", () => {
+      expect(koso.toParents()).toStrictEqual({});
+    });
+
+    it("doc with one task has root parent", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      expect(koso.toParents()).toStrictEqual({
+        [id1]: ["root"],
+      });
+    });
+
+    it("doc with two tasks has root as parent for both", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      expect(koso.toParents()).toStrictEqual({
+        [id1]: ["root"],
+        [id2]: ["root"],
+      });
+    });
+
+    it("doc with a task with two parents", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      koso.linkNode(id2, id1, 0);
+
+      expect(koso.toParents()).toStrictEqual({
+        [id1]: ["root"],
+        [id2]: ["root", id1],
+      });
     });
   });
 
   describe("graph", () => {
     it("empty graph renders successfully", () => {
-      expect(koso.yGraph.toJSON()).toStrictEqual({});
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: {
+          num: "0",
+          name: "Root",
+          children: [],
+          reporter: null,
+          assignee: null,
+          status: null,
+        },
+      });
     });
 
     it("graph with one root node renders to json successfully", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { id: "root", num: "0", name: "Root", children: [id1] },
+        [id1]: {
+          id: id1,
           num: "1",
           name: "Task 1",
           children: [],
@@ -110,394 +180,197 @@ describe("Koso tests", () => {
     });
 
     it("populated graph renders to json successfully", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { id: "root", num: "0", name: "Root", children: [id1] },
+        [id1]: { id: id1, num: "1", name: "Task 1", children: [id2] },
+        [id2]: { id: id2, num: "2", name: "Task 2", children: [] },
       });
     });
 
-    it("reparent root node 2 to root node 1 succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      addItem(koso, "id2", "2", "Task 2", []);
+    it("link node 2 to node 1 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
 
-      koso.linkNode("id2", "id1", 0);
+      koso.linkNode(id2, id1, 0);
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1, id2] },
+        [id1]: { id: id1, children: [id2] },
+        [id2]: { id: id2, children: [] },
       });
     });
 
-    it("unparent node 2 from node 1 succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
+    it("unlink node 2 from node 1 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 1, "Task 2", USER);
+      koso.linkNode(id2, id1, 0);
 
-      koso.unlinkNode("id2", "id1");
+      koso.unlinkNode(new Node([id1, id2]));
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1, id2] },
+        [id1]: { id: id1, children: [] },
+        [id2]: { id: id2, children: [] },
       });
     });
 
-    it("reparent root node 3 to node 1 as a peer of node 2 succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      addItem(koso, "id3", "3", "Task 3", []);
+    it("delete node 2 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
 
-      koso.linkNode("id3", "id1", 1);
+      koso.deleteNode(new Node([id1, id2]));
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2", "id3"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id3: {
-          id: "id3",
-          num: "3",
-          name: "Task 3",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toHaveProperty("root");
+      expect(koso.yGraph.toJSON()).toHaveProperty(id1);
+      expect(koso.yGraph.toJSON()).not.toHaveProperty(id2);
+    });
+
+    it("move node 3 to child of node 1 as a peer of node 2 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      const id3 = koso.insertNode("root", 1, "Task 3", USER);
+
+      koso.moveNode(id3, "root", 1, id1, 1);
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1] },
+        [id1]: { children: [id2, id3] },
+        [id2]: { children: [] },
+        [id3]: { children: [] },
       });
     });
 
-    it("reparent root node 3 to node 1 as the immediate child succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      addItem(koso, "id3", "3", "Task 3", []);
+    it("move node 3 to immediate child of node 1 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      const id3 = koso.insertNode("root", 1, "Task 3", USER);
 
-      koso.linkNode("id3", "id1", 0);
+      koso.moveNode(id3, "root", 1, id1, 0);
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id3", "id2"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id3: {
-          id: "id3",
-          num: "3",
-          name: "Task 3",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1] },
+        [id1]: { children: [id3, id2] },
+        [id2]: { children: [] },
+        [id3]: { children: [] },
       });
     });
 
-    it("editing node 2's name succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", []);
-      addItem(koso, "id2", "2", "Task 2", []);
+    it("move node 4 to be a child of node 3 succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      const id3 = koso.insertNode(id1, 1, "Task 3", USER);
+      const id4 = koso.insertNode(id1, 2, "Task 4", USER);
 
-      koso.editTaskName("id2", "Edited Task 2");
+      koso.moveNode(id4, id1, 2, id3, 0);
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Edited Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-      });
-    });
-
-    it("move node 4 to be a child of node 3 removes it as a child from node 1", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2", "id3", "id4"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      addItem(koso, "id3", "3", "Task 3", []);
-      addItem(koso, "id4", "4", "Task 4", []);
-
-      koso.moveNode("id4", "id1", 2, "id3", 0);
-
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2", "id3"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id3: {
-          id: "id3",
-          num: "3",
-          name: "Task 3",
-          children: ["id4"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id4: {
-          id: "id4",
-          num: "4",
-          name: "Task 4",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1] },
+        [id1]: { children: [id2, id3] },
+        [id2]: { children: [] },
+        [id3]: { children: [id4] },
+        [id4]: { children: [] },
       });
     });
 
     it("move node 4 to be the peer of node 2 succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2", "id3", "id4"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      addItem(koso, "id3", "3", "Task 3", []);
-      addItem(koso, "id4", "4", "Task 4", []);
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      const id3 = koso.insertNode(id1, 1, "Task 3", USER);
+      const id4 = koso.insertNode(id1, 2, "Task 4", USER);
 
-      koso.moveNode("id4", "id1", 2, "id1", 1);
+      koso.moveNode(id4, id1, 2, id1, 1);
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2", "id4", "id3"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id3: {
-          id: "id3",
-          num: "3",
-          name: "Task 3",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id4: {
-          id: "id4",
-          num: "4",
-          name: "Task 4",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1] },
+        [id1]: { children: [id2, id4, id3] },
+        [id2]: { children: [] },
+        [id3]: { children: [] },
+        [id4]: { children: [] },
       });
     });
 
     it("move node 3 to be the peer of node 4 succeeds", () => {
-      addItem(koso, "id1", "1", "Task 1", ["id2", "id3", "id4"]);
-      addItem(koso, "id2", "2", "Task 2", []);
-      addItem(koso, "id3", "3", "Task 3", []);
-      addItem(koso, "id4", "4", "Task 4", []);
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode(id1, 0, "Task 2", USER);
+      const id3 = koso.insertNode(id1, 1, "Task 3", USER);
+      const id4 = koso.insertNode(id1, 2, "Task 4", USER);
 
-      koso.moveNode("id3", "id1", 1, "id1", 3);
+      koso.moveNode(id3, id1, 1, id1, 3);
 
-      expect(koso.yGraph.toJSON()).toStrictEqual({
-        id1: {
-          id: "id1",
-          num: "1",
-          name: "Task 1",
-          children: ["id2", "id4", "id3"],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id2: {
-          id: "id2",
-          num: "2",
-          name: "Task 2",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id3: {
-          id: "id3",
-          num: "3",
-          name: "Task 3",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
-        id4: {
-          id: "id4",
-          num: "4",
-          name: "Task 4",
-          children: [],
-          reporter: "t@koso.app",
-          assignee: null,
-          status: null,
-        },
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { children: [id1] },
+        [id1]: { children: [id2, id4, id3] },
+        [id2]: { children: [] },
+        [id3]: { children: [] },
+        [id4]: { children: [] },
       });
     });
+  });
 
-    it("insert node creates a new untitled task", () => {
-      addItem(koso, "id1", "1", "Task 1", ["idB", "id3"]);
-      addItem(koso, "idB", "2", "Task B", []);
-      addItem(koso, "id3", "3", "Task 3", []);
+  describe("setTaskName", () => {
+    it("set node 2's name succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 0, "Task 2", USER);
 
-      koso.insertNode("id1", 2, {
-        email: "test@koso.app",
-        exp: 0,
-        name: "Test",
+      koso.setTaskName(id2, "Edited Task 2");
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { name: "Root" },
+        [id1]: { name: "Task 1" },
+        [id2]: { name: "Edited Task 2" },
+      });
+    });
+  });
+
+  describe("setAssignee", () => {
+    it("set node 2's assignee succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 0, "Task 2", USER);
+
+      koso.setAssignee(id2, USER);
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { assignee: null },
+        [id1]: { assignee: null },
+        [id2]: { assignee: "t@koso.app" },
+      });
+    });
+  });
+
+  describe("setReporter", () => {
+    it("set node 2's reporter succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 0, "Task 2", USER);
+
+      koso.setReporter(id2, {
+        email: "new@koso.app",
+        name: "New Test User",
         picture: "",
+        exp: 0,
       });
 
-      const graph = koso.yGraph.toJSON();
-      expect(Object.keys(graph)).toHaveLength(4);
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { reporter: null },
+        [id1]: { reporter: "t@koso.app" },
+        [id2]: { reporter: "new@koso.app" },
+      });
+    });
+  });
 
-      const idMatching = expect.stringMatching(/[0-9a-f-]{36}/);
-      expect(graph).toStrictEqual(
-        expect.objectContaining({
-          id1: {
-            id: "id1",
-            num: "1",
-            name: "Task 1",
-            children: ["idB", "id3", idMatching],
-            reporter: "t@koso.app",
-            assignee: null,
-            status: null,
-          },
-          idB: {
-            id: "idB",
-            num: "2",
-            name: "Task B",
-            children: [],
-            reporter: "t@koso.app",
-            assignee: null,
-            status: null,
-          },
-          id3: {
-            id: "id3",
-            num: "3",
-            name: "Task 3",
-            children: [],
-            reporter: "t@koso.app",
-            assignee: null,
-            status: null,
-          },
-        }),
-      );
+  describe("setTaskStatus", () => {
+    it("set node 2's reporter succeeds", () => {
+      const id1 = koso.insertNode("root", 0, "Task 1", USER);
+      const id2 = koso.insertNode("root", 0, "Task 2", USER);
 
-      // Also verify the inserted task, a child of task id1
-      const insertedTaskid = graph.id1.children[2];
-      const insertedTask = graph[insertedTaskid];
-      expect(insertedTask.id).toStrictEqual(insertedTaskid);
-      expect(graph[insertedTaskid]).toStrictEqual({
-        id: idMatching,
-        num: "4",
-        name: "Untitled",
-        children: [],
-        reporter: "test@koso.app",
-        assignee: null,
-        status: null,
+      koso.setTaskStatus(id2, "Done");
+
+      expect(koso.yGraph.toJSON()).toMatchObject({
+        root: { status: null },
+        [id1]: { status: null },
+        [id2]: { status: "Done" },
       });
     });
   });

--- a/frontend/src/lib/task-status-select.svelte
+++ b/frontend/src/lib/task-status-select.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
+  import type { Status } from "./koso";
   import TaskStatus from "./task-status.svelte";
 
-  const dispatch = createEventDispatcher<{ select: string }>();
+  const dispatch = createEventDispatcher<{ select: Status }>();
 
-  const statuses: string[] = ["Not Started", "In Progress", "Done"];
+  const statuses: Status[] = ["Not Started", "In Progress", "Done"];
 
-  function select(status: string) {
+  function select(status: Status) {
     dispatch("select", status);
   }
 </script>

--- a/frontend/src/routes/(auth)/projects/[slug]/+page.svelte
+++ b/frontend/src/routes/(auth)/projects/[slug]/+page.svelte
@@ -14,6 +14,7 @@
 
   const projectId = $page.params.slug;
   const koso = new Koso(projectId, new Y.Doc());
+  window.koso = koso;
 
   let users: User[] = [];
   let project: Project | null = null;


### PR DESCRIPTION
- yGraph is now rooted at a single root task with the ID "root"
  - Root node is identified by the empty path: (`[]`)
  - Added migration flow to update any existing yGraph that doesn't have a root
- Koso object is exposed to the JavaScript console at `window.koso`
- Add `koso.toParents()` method to be able to quickly lookup the parents of a task
- Mark some methods in Koso private
- Refactored Koso tests to only use Koso public interface
- Refactored status to be a typescript Status enum instead of a plain string