### PR TITLE
Move tasks to the end when marked done

### DIFF
--- a/frontend/src/lib/dag-table/row.svelte
+++ b/frontend/src/lib/dag-table/row.svelte
@@ -364,7 +364,7 @@
       <TaskStatusSelect
         value={task.status}
         on:select={(event) => {
-          koso.setTaskStatus(task.id, event.detail);
+          koso.setTaskStatus(node, event.detail);
         }}
       />
     {:else}

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -397,7 +397,7 @@ describe("Koso tests", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 0, USER, "Task 2");
 
-      koso.setTaskStatus(id2.name, "Done");
+      koso.setTaskStatus(id2, "Done");
 
       expect(koso.toJSON()).toMatchObject({
         root: { status: null },
@@ -419,7 +419,7 @@ describe("Koso tests", () => {
 
     it("leaf node that is in progress has 0 of 1 progress", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
-      koso.setTaskStatus(id1.name, "In Progress");
+      koso.setTaskStatus(id1, "In Progress");
 
       expect(koso.getProgress(id1.name)).toEqual({
         numer: 0,
@@ -429,7 +429,7 @@ describe("Koso tests", () => {
 
     it("leaf node that is done has 1 of 1 progress", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
-      koso.setTaskStatus(id1.name, "Done");
+      koso.setTaskStatus(id1, "Done");
 
       expect(koso.getProgress(id1.name)).toEqual({
         numer: 1,
@@ -452,8 +452,8 @@ describe("Koso tests", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 2");
       const id3 = koso.insertNode(id1, 0, USER, "Task 3");
-      koso.setTaskStatus(id2.name, "In Progress");
-      koso.setTaskStatus(id3.name, "In Progress");
+      koso.setTaskStatus(id2, "In Progress");
+      koso.setTaskStatus(id3, "In Progress");
 
       expect(koso.getProgress(id1.name)).toEqual({
         numer: 0,
@@ -465,8 +465,8 @@ describe("Koso tests", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 2");
       const id3 = koso.insertNode(id1, 0, USER, "Task 3");
-      koso.setTaskStatus(id2.name, "Done");
-      koso.setTaskStatus(id3.name, "In Progress");
+      koso.setTaskStatus(id2, "Done");
+      koso.setTaskStatus(id3, "In Progress");
 
       expect(koso.getProgress(id1.name)).toEqual({
         numer: 1,

--- a/frontend/src/lib/koso.ts
+++ b/frontend/src/lib/koso.ts
@@ -143,8 +143,18 @@ export class Koso {
       (nodes) => JSON.stringify(nodes.map((node) => node.id)),
     );
 
-    this.nodes = derived([this.expanded, this.events], ([expanded]) =>
-      this.#flatten(new Node(), expanded),
+    this.nodes = derived(
+      [this.expanded, this.events],
+      ([expanded]): List<Node> => {
+        // The nodes store is consistently initialized prior to the ygraph
+        // being loaded, but #flatten expects the presence of at least a
+        // "root" task. Handle the situation here to avoid generating warnings
+        // in #flatten.
+        if (this.yGraph.size === 0) {
+          return List();
+        }
+        return this.#flatten(new Node(), expanded);
+      },
     );
   }
 
@@ -256,10 +266,26 @@ export class Koso {
     return offset;
   }
 
-  getPrevPeer(node: Node): Node {
+  getPrevPeer(node: Node): Node | null {
     const peers = this.getChildren(node.parent.name);
     const offset = peers.indexOf(node.name);
-    return node.parent.child(peers[offset - 1]);
+    if (offset === -1) throw new Error(`Node ${node.name} not found in parent`);
+    const prevPeerOffset = offset - 1;
+    if (prevPeerOffset < 0) {
+      return null;
+    }
+    return node.parent.child(peers[prevPeerOffset]);
+  }
+
+  getNextPeer(node: Node): Node | null {
+    const peers = this.getChildren(node.parent.name);
+    const offset = peers.indexOf(node.name);
+    if (offset === -1) throw new Error(`Node ${node.name} not found in parent`);
+    const nextPeerOffset = offset + 1;
+    if (nextPeerOffset > peers.length - 1) {
+      return null;
+    }
+    return node.parent.child(peers[nextPeerOffset]);
   }
 
   #getYTask(taskId: string): Y.Map<string | Y.Array<string> | null> {
@@ -497,14 +523,14 @@ export class Koso {
 
   canIndentNode(node: Node) {
     const peer = this.getPrevPeer(node);
-    return this.canMove(node, peer.name);
+    return peer && this.canMove(node, peer.name);
   }
 
   indentNode(node: Node) {
     const offset = this.getOffset(node);
     if (offset < 1) return;
     const peer = this.getPrevPeer(node);
-    if (!this.canIndentNode(node)) return;
+    if (!peer || !this.canIndentNode(node)) return;
     this.moveNode(node, peer.name, this.getChildCount(peer.name));
     this.expand(peer);
     this.selected.set(peer.child(node.name));
@@ -580,22 +606,28 @@ export class Koso {
     });
   }
 
-  setTaskStatus(taskId: string, status: Status | null) {
+  setTaskStatus(node: Node, status: Status | null) {
+    const taskId = node.name;
     this.yDoc.transact(() => {
       const yNode = this.yGraph.get(taskId);
       if (!yNode) throw new Error(`Task ${taskId} is not in the graph`);
-      if (yNode.get("status") !== status) {
-        yNode.set("status", status);
+      if (yNode.get("status") === status) return;
 
-        // When a task is marked done, make it the last child.
-        if (status === "Done") {
-          for (const parentTask of this.yGraph.values()) {
-            const children = parentTask.get("children") as Y.Array<string>;
-            const index = children.slice().indexOf(taskId);
-            if (index !== -1) {
-              children.delete(index);
-              children.push([taskId]);
-            }
+      yNode.set("status", status);
+      // When a task is marked done, make it the last child
+      // and select an adjacent peer.
+      if (status === "Done") {
+        const peer = this.getPrevPeer(node) || this.getNextPeer(node);
+        if (peer) {
+          this.selected.set(peer);
+        }
+
+        for (const parentTask of this.yGraph.values()) {
+          const children = parentTask.get("children") as Y.Array<string>;
+          const index = children.slice().indexOf(taskId);
+          if (index !== -1) {
+            children.delete(index);
+            children.push([taskId]);
           }
         }
       }

--- a/frontend/src/lib/task-status-select.svelte
+++ b/frontend/src/lib/task-status-select.svelte
@@ -40,5 +40,5 @@
 </DropdownMenuMonitoredRoot>
 
 {#if showConfetti}
-  <Confetti />
+  <div class="fixed left-1/2 top-1/2"><Confetti /></div>
 {/if}


### PR DESCRIPTION
Unfortunately, if the list is long enough such that the newly done row moves out of the viewport, things don't work well. The window scrolls a little but not enough to keep the element in view. Though, with animations disabled, things work as expected.