### PR TITLE
Remove grouping for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    groups:
-      docker-deps:
-        patterns:
-          - '*'


### PR DESCRIPTION
Groups don't seem to work here for some reason. Perhaps because we don't use any versioned base images in Dockerfile. Dependabot complains about skipping things.