### PR TITLE
Delay rendering the dag table until after the initial sync

### DIFF
--- a/frontend/src/lib/dag-table/table.svelte
+++ b/frontend/src/lib/dag-table/table.svelte
@@ -365,7 +365,9 @@
 <CommandPalette bind:open={commandPaletteOpen} {actions} />
 
 <div class="mb-12 p-2 sm:mb-0">
-  {#if !$syncState.serverSync && !$syncState.indexedDbSync}{:else if $nodes.size > 1}
+  {#if !$syncState.serverSync && !$syncState.indexedDbSync}
+    <!-- Loading.-->
+  {:else if $nodes.size > 1}
     <table class="w-full border-separate border-spacing-0 rounded-md border">
       <thead class="text-left text-xs font-bold uppercase">
         <tr>

--- a/frontend/src/lib/koso.ts
+++ b/frontend/src/lib/koso.ts
@@ -93,7 +93,9 @@ export type YTaskProps = Y.Array<string> | string | number | null;
 export type YTask = Y.Map<YTaskProps>;
 
 export type SyncState = {
+  // True when the indexed DB is sync'd with the Koso doc.
   indexedDbSync: boolean;
+  // True when state from the server is sync'd with the Koso doc.
   serverSync: boolean;
 };
 


### PR DESCRIPTION
This avoids flashes of default content, especially noticeable in dark mode thanks to my lack of thematic styling!