### PR TITLE
Fetch instead of pull in deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,10 @@ jobs:
             set -e
             echo "Deploying commit ${GITHUB_SHA}, image digest ${KOSO_IMAGE_DIGEST}"
             cd /root/koso
+            git status
             git reset --hard
             git clean -f -d
-            git checkout main
-            git pull
+            git fetch
             git checkout $GITHUB_SHA
             git status
             ./deploy.sh


### PR DESCRIPTION
We always target a specific commit so there's no need to jump to main. Just fetch and then checkout the commit.