### PR TITLE
Make `pnpm test` do all the things

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: pnpm install
-      - run: pnpm run "/^(build|check|lint|test)$/"
+      - run: pnpm run "/^(build|check|lint|test:unit)$/"
   playwright:
     runs-on: ubuntu-latest
     defaults:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,13 +8,13 @@
     "dev": "vite dev",
     "build": "svelte-kit sync && vite build",
     "preview": "vite preview",
-    "test": "pnpm run test:unit",
+    "test": "pnpm run \"/^(check|lint|test:unit|test:integration)$/\"",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
     "test:integration": "playwright test",
-    "test:unit": "vitest"
+    "test:unit": "vitest run"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",

--- a/frontend/src/lib/components/ui/confetti/confetti.svelte
+++ b/frontend/src/lib/components/ui/confetti/confetti.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
   class ConfettiState {
     rects: DOMRect[] = $state([]);
 


### PR DESCRIPTION
Example:

```shell
$ pnpm test

> koso@0.0.1 test /Users/shad/Workspace/koso/frontend
> pnpm run "/^(check|lint|test:unit|test:integration)$/"

. check$ svelte-kit sync && svelte-check --tsconfig ./tsconfig.json
[25 lines collapsed]
│     cx: 50%;
│     cy: 50%;
│     r: var(--_cp-radius);
│ /Users/shad/Workspace/koso/frontend/src/lib/components/ui/circular-progress/circular-progress.svelte:84:5
│ Warn: Unknown property: 'r' (css)
│     cy: 50%;
│     r: var(--_cp-radius);
│     stroke: var(--cp-fill-color);
│ ====================================
│ svelte-check found 0 errors and 6 warnings in 1 file
└─ Done in 13.2s
. lint$ prettier --check . && eslint .
│ Checking formatting...
│ (node:99844) ExperimentalWarning: CommonJS module /Users/shad/Workspace/koso/frontend/node_modules/.pnpm/…
│ Support for loading ES Module in require() is an experimental feature and might change at any time
│ (Use `node --trace-warnings ...` to show where the warning was created)
│ All matched files use Prettier code style!
└─ Done in 11.6s
. test:integration$ playwright test
[29 lines collapsed]
│   ✓  33 new-project-test.ts:17:3 › new project › home page presents login header and button (432ms)
│   ✓  28 dag-table-test.ts:190:5 › dag table tests › deleting tasks › delete last task by pressing the Del…
│   ✓  32 dag-table-test.ts:1441:5 › dag table tests › status icon › four out of four tasks complete shows …
│   ✓  31 dag-table-test.ts:1016:7 › dag table tests › movement using keyboard bindings › option up and dow…
│   ✓  34 new-project-test.ts:22:3 › new project › log user in and view projects (915ms)
│   ✓  36 new-project-test.ts:34:3 › new project › create a project and rename it to Integration Test Proje…
│   ✓  29 dag-table-test.ts:1308:5 › dag table tests › drag and drop › move task 1 to child of task 2 and l…
│   ✓  35 dag-table-test.ts:1065:7 › dag table tests › movement using keyboard bindings › option up and dow…
│   ✓  37 dag-table-test.ts:1338:5 › dag table tests › drag and drop › cannot make task 1 child of itself (…
│   37 passed (17.3s)
└─ Done in 17.7s
. test:unit$ vitest run
│  RUN  v2.1.3 /Users/shad/Workspace/koso/frontend
│  ✓ src/lib/stores.test.ts  (7 tests) 7ms
│ (node:99841) ExperimentalWarning: CommonJS module /Users/shad/Workspace/koso/frontend/node_modules/.pnpm/…
│ Support for loading ES Module in require() is an experimental feature and might change at any time
│ (Use `node --trace-warnings ...` to show where the warning was created)
│  ✓ src/lib/koso.test.ts  (41 tests) 237ms
│  Test Files  2 passed (2)
│       Tests  48 passed (48)
│    Start at  14:23:40
│    Duration  3.77s (transform 1.77s, setup 423ms, collect 3.72s, tests 244ms, environment 507ms, prepare …
└─ Done in 4.5s
```