### PR TITLE
Fix shifting focus when expanding or collapsing other nodes

### DIFF
--- a/frontend/src/lib/components/ui/editable/editable.svelte
+++ b/frontend/src/lib/components/ui/editable/editable.svelte
@@ -10,6 +10,7 @@
     editing?: boolean;
     class?: string;
     "aria-label"?: string;
+    closeFocus?: HTMLElement;
     onclick?: (event: MouseEvent) => void;
     // Callback invoked to apply the edited value.
     // May throw or return a failed promise if save fails
@@ -24,6 +25,7 @@
     placeholder = "Click to edit",
     class: classes,
     "aria-label": ariaLabel,
+    closeFocus,
     onclick,
     onsave,
     ondone,
@@ -77,22 +79,25 @@
     // This occurs as part of the normal flow due to
     // both the onblur and "Save" action callbacks triggering.
     if (value === edited) {
-      ondone?.();
-      editing = false;
+      done();
       return;
     }
 
     onsave(edited).then(() => {
       value = edited;
-      ondone?.();
-      editing = false;
+      done();
     });
+  }
+
+  function done() {
+    ondone?.();
+    closeFocus?.focus();
+    editing = false;
   }
 
   function revert() {
     edited = value;
-    ondone?.();
-    editing = false;
+    done();
   }
 </script>
 

--- a/frontend/src/lib/dag-table/link-panel.svelte
+++ b/frontend/src/lib/dag-table/link-panel.svelte
@@ -22,13 +22,13 @@
       ? Object.values(koso.graph)
           .filter((task) => match(task.num, query) || match(task.name, query))
           .filter((task) => task.id !== "root")
-          .filter((task) => koso.canLink(node, task.id))
+          .filter((task) => koso.canLink(node.name, task.id))
           .sort((t1, t2) => t2.children.length - t1.children.length)
       : [],
   );
 
   function link(taskId: string) {
-    koso.linkNode(node, taskId, koso.getChildCount(taskId));
+    koso.linkTask(node.name, taskId, koso.getChildCount(taskId));
     query = "";
     open = false;
   }
@@ -54,7 +54,12 @@
       <Command.List>
         <Command.Empty>No tasks found.</Command.Empty>
         {#each tasks as task (task.id)}
-          <Command.Item class="table-row" onSelect={() => link(task.id)}>
+          <Command.Item
+            class="table-row"
+            onSelect={() => link(task.id)}
+            role="button"
+            aria-label="Task {task.id} Command Item"
+          >
             <div class="table-cell rounded-l px-2 align-middle">
               <div class="flex items-center gap-1 py-2" title="Task Number">
                 <Clipboard size={16} />

--- a/frontend/src/lib/dag-table/row.svelte
+++ b/frontend/src/lib/dag-table/row.svelte
@@ -58,8 +58,8 @@
   let tags = $derived(getTags(koso.parents));
 
   $effect(() => {
-    if (rowElement && node.equals(koso.selected)) {
-      rowElement.focus();
+    if (isSelected) {
+      rowElement?.focus();
     }
   });
 

--- a/frontend/src/lib/dag-table/row.svelte
+++ b/frontend/src/lib/dag-table/row.svelte
@@ -58,8 +58,9 @@
   let tags = $derived(getTags(koso.parents));
 
   $effect(() => {
-    if (isSelected) {
-      rowElement?.focus();
+    if (rowElement && isSelected && koso.focus) {
+      rowElement.focus();
+      koso.focus = false;
     }
   });
 
@@ -192,7 +193,7 @@
       return;
     }
 
-    const dragDestParent = node.parent.name;
+    const dragDestParent = node.parent;
     const dragDestOffset = koso.getOffset(node) + 1;
 
     if (koso.dropEffect === "copy") {
@@ -213,7 +214,7 @@
       return;
     }
 
-    const dragDestParent = node.name;
+    const dragDestParent = node;
     const dragDestOffset = 0;
 
     if (koso.dropEffect === "copy") {
@@ -235,11 +236,11 @@
       return;
     }
 
-    if (koso.canLink(koso.dragged, node.parent.name)) {
+    if (koso.canLink(koso.dragged, node.parent)) {
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverPeer = true;
-    } else if (koso.canMove(koso.dragged, node.parent.name)) {
+    } else if (koso.canMove(koso.dragged, node.parent)) {
       dataTransfer.dropEffect = "move";
       koso.dropEffect = "move";
       dragOverPeer = true;
@@ -256,11 +257,11 @@
       return;
     }
 
-    if (koso.canLink(koso.dragged, node.name)) {
+    if (koso.canLink(koso.dragged, node)) {
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverChild = true;
-    } else if (koso.canMove(koso.dragged, node.name)) {
+    } else if (koso.canMove(koso.dragged, node)) {
       dataTransfer.dropEffect = "move";
       koso.dropEffect = "move";
       dragOverChild = true;
@@ -395,6 +396,7 @@
         value={task.name}
         aria-label={`Task ${task.num} Edit Name`}
         editing={isEditing}
+        closeFocus={rowElement}
         onclick={() => (koso.selected = node)}
         onsave={async (name) => {
           koso.setTaskName(task.id, name);

--- a/frontend/src/lib/dag-table/row.svelte
+++ b/frontend/src/lib/dag-table/row.svelte
@@ -236,7 +236,7 @@
       return;
     }
 
-    if (koso.canLink(koso.dragged, node.parent)) {
+    if (koso.canLink(koso.dragged.name, node.parent.name)) {
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverPeer = true;
@@ -257,7 +257,7 @@
       return;
     }
 
-    if (koso.canLink(koso.dragged, node)) {
+    if (koso.canLink(koso.dragged.name, node.name)) {
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverChild = true;

--- a/frontend/src/lib/koso.svelte.ts
+++ b/frontend/src/lib/koso.svelte.ts
@@ -99,7 +99,8 @@ export class Koso {
   yIndexedDb: IndexeddbPersistence;
   clientMessageHandler: (message: Uint8Array) => void;
 
-  selected: Node | null = $state(null);
+  #selected: Node | null = $state(null);
+  focus: boolean = $state(false);
   highlighted: string | null = $state(null);
   dragged: Node | null = $state(null);
   dropEffect: "copy" | "move" | "none" = $state("none");
@@ -197,6 +198,15 @@ export class Koso {
 
   destroy() {
     this.unobserve(this.#observer);
+  }
+
+  get selected(): Node | null {
+    return this.#selected;
+  }
+
+  set selected(value: Node | null) {
+    this.#selected = value;
+    this.focus = true;
   }
 
   get root(): Node {
@@ -593,25 +603,26 @@ export class Koso {
     yChildren.insert(offset, [child]);
   }
 
-  canLink(node: Node, parent: string): boolean {
+  canLink(node: Node, parent: Node): boolean {
     return (
-      !this.#hasCycle(parent, node.name) && !this.#hasChild(parent, node.name)
+      !this.#hasCycle(parent.name, node.name) &&
+      !this.#hasChild(parent.name, node.name)
     );
   }
 
-  linkNode(node: Node, parent: string, offset: number) {
+  linkNode(node: Node, parent: Node, offset: number) {
     if (!this.canLink(node, parent))
       throw new Error(`Cannot link ${node.name} to ${parent}`);
     this.yDoc.transact(() => {
-      this.#insertChild(node.name, parent, offset);
+      this.#insertChild(node.name, parent.name, offset);
     });
   }
 
-  canMove(node: Node, parent: string): boolean {
-    return node.parent.name === parent || this.canLink(node, parent);
+  canMove(node: Node, parent: Node): boolean {
+    return node.parent.name === parent.name || this.canLink(node, parent);
   }
 
-  moveNode(node: Node, parent: string, offset: number) {
+  moveNode(node: Node, parent: Node, offset: number) {
     if (offset < 0) {
       throw new Error(`Cannot move  ${node.name} to negative offset ${offset}`);
     }
@@ -623,15 +634,16 @@ export class Koso {
       const ySrcChildren = this.#getYChildren(srcParentName);
       ySrcChildren.delete(srcOffset);
 
-      if (srcParentName === parent && srcOffset < offset) {
+      if (srcParentName === parent.name && srcOffset < offset) {
         offset -= 1;
       }
-      this.#insertChild(node.name, parent, offset);
+      this.#insertChild(node.name, parent.name, offset);
     });
+    this.selected = parent.child(node.name);
   }
 
   reorderNode(node: Node, offset: number) {
-    this.moveNode(node, node.parent.name, offset);
+    this.moveNode(node, node.parent, offset);
   }
 
   moveNodeUp(node: Node) {
@@ -649,11 +661,11 @@ export class Koso {
           `Trying to move up: newParent: ${newParent.id}, offset: ${newOffset}`,
         );
       }
-      if (!this.canMove(node, newParent.name)) {
+      if (!this.canMove(node, newParent)) {
         attempts++;
         return false;
       }
-      this.moveNode(node, newParent.name, newOffset);
+      this.moveNode(node, newParent, newOffset);
       this.selected = newParent.child(node.name);
       if (attempts > 0) {
         toast.info(
@@ -741,11 +753,11 @@ export class Koso {
           `Trying to move down: newParent: ${newParent.id}, offset: ${newOffset}`,
         );
       }
-      if (!this.canMove(node, newParent.name)) {
+      if (!this.canMove(node, newParent)) {
         attempts++;
         return false;
       }
-      this.moveNode(node, newParent.name, newOffset);
+      this.moveNode(node, newParent, newOffset);
       this.selected = newParent.child(node.name);
       if (attempts > 0) {
         toast.info(
@@ -852,27 +864,27 @@ export class Koso {
 
   canIndentNode(node: Node): boolean {
     const peer = this.getPrevPeer(node);
-    return !!peer && this.canMove(node, peer.name);
+    return !!peer && this.canMove(node, peer);
   }
 
   indentNode(node: Node) {
     const peer = this.getPrevPeer(node);
     if (!peer || !this.canIndentNode(node)) return;
-    this.moveNode(node, peer.name, this.getChildCount(peer.name));
+    this.moveNode(node, peer, this.getChildCount(peer.name));
     this.expand(peer);
     this.selected = peer.child(node.name);
   }
 
   canUndentNode(node: Node): boolean {
     if (node.length < 2) return false;
-    return this.canMove(node, node.parent.parent.name);
+    return this.canMove(node, node.parent.parent);
   }
 
   undentNode(node: Node) {
     if (!this.canUndentNode(node)) return;
     const parent = node.parent;
     const offset = this.getOffset(parent);
-    this.moveNode(node, parent.parent.name, offset + 1);
+    this.moveNode(node, parent.parent, offset + 1);
     this.selected = parent.parent.child(node.name);
   }
 

--- a/frontend/src/lib/koso.svelte.ts
+++ b/frontend/src/lib/koso.svelte.ts
@@ -603,23 +603,26 @@ export class Koso {
     yChildren.insert(offset, [child]);
   }
 
-  canLink(node: Node, parent: Node): boolean {
-    return (
-      !this.#hasCycle(parent.name, node.name) &&
-      !this.#hasChild(parent.name, node.name)
-    );
+  canLink(task: string, parent: string): boolean {
+    return !this.#hasCycle(parent, task) && !this.#hasChild(parent, task);
   }
 
-  linkNode(node: Node, parent: Node, offset: number) {
-    if (!this.canLink(node, parent))
-      throw new Error(`Cannot link ${node.name} to ${parent}`);
+  linkTask(task: string, parent: string, offset: number) {
+    if (!this.canLink(task, parent))
+      throw new Error(`Cannot link ${task} to ${parent}`);
     this.yDoc.transact(() => {
-      this.#insertChild(node.name, parent.name, offset);
+      this.#insertChild(task, parent, offset);
     });
   }
 
+  linkNode(node: Node, parent: Node, offset: number) {
+    this.linkTask(node.name, parent.name, offset);
+  }
+
   canMove(node: Node, parent: Node): boolean {
-    return node.parent.name === parent.name || this.canLink(node, parent);
+    return (
+      node.parent.name === parent.name || this.canLink(node.name, parent.name)
+    );
   }
 
   moveNode(node: Node, parent: Node, offset: number) {

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -120,7 +120,7 @@ describe("Koso tests", () => {
     it("doc with two tasks, one linked subtask, and parent is expanded has three nodes", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 1, USER, "Task 2");
-      koso.linkNode(id2, id1.name, 0);
+      koso.linkNode(id2, id1, 0);
       koso.expanded = Set([id1]);
       const lid = id1.child(id2.name);
       expect(koso.nodes).toStrictEqual(List([root, id1, lid, id2]));
@@ -177,7 +177,7 @@ describe("Koso tests", () => {
     it("link node 2 to node 1 succeeds", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 1, USER, "Task 2");
-      koso.linkNode(id2, id1.name, 0);
+      koso.linkNode(id2, id1, 0);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name, id2.name] },
@@ -189,7 +189,7 @@ describe("Koso tests", () => {
     it("delete node 2 from node 1 succeeds", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 1, USER, "Task 2");
-      koso.linkNode(id2, id1.name, 0);
+      koso.linkNode(id2, id1, 0);
       koso.expanded = Set([id1]);
 
       koso.deleteNode(id1.child(id2.name));
@@ -210,7 +210,7 @@ describe("Koso tests", () => {
       const id5 = koso.insertNode(id3, 0, USER, "Task 5");
       koso.insertNode(id4, 0, USER, "Task 6");
       const id7 = koso.insertNode(root, 2, USER, "Task 7");
-      koso.linkNode(id3, id7.name, 0);
+      koso.linkNode(id3, id7, 0);
       koso.deleteNode(id2);
 
       expect(koso.toJSON()).toMatchObject({
@@ -226,7 +226,7 @@ describe("Koso tests", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 1, USER, "Task 2");
       const id3 = koso.insertNode(id2, 0, USER, "Task 3");
-      koso.linkNode(id2, id1.name, 0);
+      koso.linkNode(id2, id1, 0);
       koso.deleteNode(id2);
 
       expect(koso.toJSON()).toMatchObject({
@@ -251,13 +251,13 @@ describe("Koso tests", () => {
 
     it("link node 1 to child of node 1 throws (prevent cycle)", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
-      expect(() => koso.linkNode(id1, id1.name, 0)).toThrow();
+      expect(() => koso.linkNode(id1, id1, 0)).toThrow();
     });
 
     it("link node 1 to grandchild of node 1 throws (prevent cycle)", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 1");
-      expect(() => koso.linkNode(id1, id2.name, 0)).toThrow();
+      expect(() => koso.linkNode(id1, id2, 0)).toThrow();
     });
 
     it("move node 3 to child of node 1 as a peer of node 2 succeeds (reparent)", () => {
@@ -266,7 +266,7 @@ describe("Koso tests", () => {
       const id3 = koso.insertNode(root, 1, USER, "Task 3");
       koso.expanded = Set([id1]);
 
-      koso.moveNode(id3, id1.name, 1);
+      koso.moveNode(id3, id1, 1);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name] },
@@ -282,7 +282,7 @@ describe("Koso tests", () => {
       const id3 = koso.insertNode(root, 1, USER, "Task 3");
       koso.expanded = Set([id1]);
 
-      koso.moveNode(id3, id1.name, 0);
+      koso.moveNode(id3, id1, 0);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name] },
@@ -299,7 +299,7 @@ describe("Koso tests", () => {
       const id4 = koso.insertNode(id1, 2, USER, "Task 4");
       koso.expanded = Set([id1, id3]);
 
-      koso.moveNode(id4, id3.name, 0);
+      koso.moveNode(id4, id3, 0);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name] },
@@ -313,10 +313,10 @@ describe("Koso tests", () => {
     it("move node 2 to peer of itself throws (prevent duplicate)", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(root, 0, USER, "Task 2");
-      koso.linkNode(id2, id1.name, 0);
+      koso.linkNode(id2, id1, 0);
       koso.expanded = Set([id1.child(id2.name)]);
 
-      expect(() => koso.moveNode(id2, id1.name, 1)).toThrow();
+      expect(() => koso.moveNode(id2, id1, 1)).toThrow();
     });
 
     it("move node 4 to be the peer of node 2 succeeds (reorder)", () => {
@@ -326,7 +326,7 @@ describe("Koso tests", () => {
       const id4 = koso.insertNode(id1, 2, USER, "Task 4");
       koso.expanded = Set([id1]);
 
-      koso.moveNode(id4, id1.name, 1);
+      koso.moveNode(id4, id1, 1);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name] },
@@ -344,7 +344,7 @@ describe("Koso tests", () => {
       const id4 = koso.insertNode(id1, 2, USER, "Task 4");
       koso.expanded = Set([id1]);
 
-      koso.moveNode(id3, id1.name, 3);
+      koso.moveNode(id3, id1, 3);
 
       expect(koso.toJSON()).toMatchObject({
         root: { children: [id1.name] },

--- a/frontend/tests/dag-table-test.ts
+++ b/frontend/tests/dag-table-test.ts
@@ -66,9 +66,11 @@ test.describe("dag table tests", () => {
   }
 
   test.describe("creating tasks", () => {
-    test("create a task by clicking the Add Task button", async ({ page }) => {
-      await page.getByRole("button", { name: "Add Task" }).last().click();
+    test("create a task by clicking the Insert button", async ({ page }) => {
+      await page.getByRole("button", { name: "Insert" }).last().click();
       await page.keyboard.press("Escape");
+
+      await expect(page.getByRole("row", { name: "Task 1" })).toBeFocused();
       await expect(page.getByRole("row", { name: "Task 1" })).toBeVisible();
 
       const graph = await getKosoGraph(page);
@@ -76,10 +78,10 @@ test.describe("dag table tests", () => {
       expect(graph["root"].children).toStrictEqual([tasks["1"]]);
     });
 
-    test("create a task by clicking the Add Task button and then edit", async ({
+    test("create a task by clicking the Insert button and then edit", async ({
       page,
     }) => {
-      await page.getByRole("button", { name: "Add Task" }).last().click();
+      await page.getByRole("button", { name: "Insert" }).last().click();
 
       await expect(
         page.getByRole("textbox", { name: "Task 1 Edit Name" }),
@@ -130,6 +132,9 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 1 Drag Handle" }).click();
       await page.keyboard.press("Alt+Shift+Enter");
+      await page.keyboard.type("Task 2 title");
+
+      await expect(page.getByRole("row", { name: "Task 2" })).not.toBeFocused();
       await expect(page.getByRole("row", { name: "Task 2" })).toBeVisible();
 
       let graph = await getKosoGraph(page);
@@ -138,6 +143,10 @@ test.describe("dag table tests", () => {
       expect(graph[tasks["1"]].children).toStrictEqual([tasks["2"]]);
 
       await page.keyboard.press("Alt+Shift+Enter");
+      await page.keyboard.type("Task 2 title");
+      await page.keyboard.press("Enter");
+
+      await expect(page.getByRole("row", { name: "Task 3" })).toBeFocused();
       await expect(page.getByRole("row", { name: "Task 3" })).toBeVisible();
 
       graph = await getKosoGraph(page);
@@ -159,9 +168,10 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 2 Drag Handle" }).click();
       await page.getByRole("button", { name: "Delete" }).click();
-      await expect(page.getByRole("row", { name: "Task 2" })).toBeHidden();
 
+      await expect(page.getByRole("row", { name: "Task 2" })).toBeHidden();
       await expect(page.getByRole("row", { name: "Task 3" })).toBeFocused();
+
       expect(await getKosoGraph(page)).toMatchObject({
         root: { children: ["1", "3"] },
         ["1"]: { children: [] },
@@ -183,9 +193,10 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 2 Drag Handle" }).click();
       await page.keyboard.press("Delete");
-      await expect(page.getByRole("row", { name: "Task 2" })).toBeHidden();
 
+      await expect(page.getByRole("row", { name: "Task 2" })).toBeHidden();
       await expect(page.getByRole("row", { name: "Task 3" })).toBeFocused();
+
       expect(await getKosoGraph(page)).toMatchObject({
         root: { children: ["1", "3"] },
         ["1"]: { children: [] },
@@ -208,10 +219,11 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 2 Drag Handle" }).click();
       await page.keyboard.press("Delete");
+
       await expect(page.getByRole("row", { name: "Task 2" })).toBeHidden();
       await expect(page.getByRole("row", { name: "Task 3" })).toBeHidden();
-
       await expect(page.getByRole("row", { name: "Task 4" })).toBeFocused();
+
       expect(await getKosoGraph(page)).toMatchObject({
         root: { children: ["1"] },
         ["1"]: { children: ["4"] },
@@ -220,13 +232,12 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 1 Drag Handle" }).click();
       await page.keyboard.press("Delete");
+
       await expect(page.getByRole("row", { name: "Task 1" })).toBeHidden();
       await expect(page.getByRole("row", { name: "Task 4" })).toBeHidden();
-
       await expect(page.getByRole("button", { name: "Delete" })).toBeHidden();
-      expect(await getKosoGraph(page)).toMatchObject({
-        root: {},
-      });
+
+      expect(await getKosoGraph(page)).toMatchObject({ root: {} });
     });
 
     test("create a task by presing Shift+Enter on the task", async ({
@@ -239,6 +250,7 @@ test.describe("dag table tests", () => {
 
       await page.getByRole("button", { name: "Task 1 Drag Handle" }).click();
       await page.keyboard.press("Shift+Enter");
+
       await expect(page.getByRole("row", { name: "Task 2" })).toBeVisible();
 
       const graph = await getKosoGraph(page);
@@ -254,6 +266,7 @@ test.describe("dag table tests", () => {
         { id: "1" },
       ]);
       await page.getByRole("button", { name: "Task 1 Drag Handle" }).click();
+
       await expect(page.getByRole("row", { name: "Task 1" })).toBeFocused();
     });
   });

--- a/frontend/tests/dag-table-test.ts
+++ b/frontend/tests/dag-table-test.ts
@@ -1486,8 +1486,7 @@ test.describe("dag table tests", () => {
   });
 
   test.describe("link panel", () => {
-    // TODO: Fix flaky test and unskip
-    test.skip("link panel adds a link to task by name", async ({ page }) => {
+    test("link panel adds a link to task by name", async ({ page }) => {
       await init(page, [
         { id: "root", name: "Root", children: ["m1", "m2", "c1", "c2"] },
         { id: "m1", name: "Milestone 1", children: ["f1", "f2"] },
@@ -1499,11 +1498,10 @@ test.describe("dag table tests", () => {
       ]);
 
       await page.getByRole("button", { name: "Task m1 Toggle Expand" }).click();
-      await page.getByRole("row", { name: "Task f1" }).click();
+      await page.getByRole("button", { name: "Task f1 Drag Handle" }).click();
 
       await page.keyboard.press("Meta+/");
-      await page.keyboard.type("Component 2");
-      await page.keyboard.press("Enter");
+      await page.getByRole("button", { name: "Task c2 Command Item" }).click();
 
       await page.getByRole("button", { name: "Task c2 Toggle Expand" }).click();
       await expect(
@@ -1521,8 +1519,7 @@ test.describe("dag table tests", () => {
       });
     });
 
-    // TODO: Fix flaky test and unskip
-    test.skip("link panel adds a link to task by ID", async ({ page }) => {
+    test("link panel adds a link to task by ID", async ({ page }) => {
       await init(page, [
         { id: "root", name: "Root", children: ["m1", "m2", "c1", "c2"] },
         { id: "m1", name: "Milestone 1", children: ["f1", "f2"] },
@@ -1537,8 +1534,7 @@ test.describe("dag table tests", () => {
       await page.getByRole("row", { name: "Task f2" }).click();
 
       await page.keyboard.press("Meta+/");
-      await page.keyboard.type("c1");
-      await page.keyboard.press("Enter");
+      await page.getByRole("button", { name: "Task c1 Command Item" }).click();
 
       await page.getByRole("button", { name: "Task c1 Toggle Expand" }).click();
       await expect(


### PR DESCRIPTION
- Add a `closeFocus` parameter to `Editable` component
- Refactor the refocus code to work via a signal in koso (`koso.focus`)
- Refactor `linkNode`, and `moveNode` to take `Node`s instead of taskIds
- Refactor `canLink` to take taskIds
- Add `linkTask` to link using taskIds instead of Nodes
- Fix integration tests and add back link-panel tests