### PR TITLE
Proxy YGraph, YTask, and YChildren

### DIFF
--- a/frontend/src/lib/components/ui/task-status/task-status-icon.svelte
+++ b/frontend/src/lib/components/ui/task-status/task-status-icon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { CircularProgress } from "$lib/components/ui/circular-progress";
-  import type { Status } from "$lib/koso.svelte";
+  import type { Status } from "$lib/yproxy";
   import { CircleCheck, CircleFadingArrowUp } from "lucide-svelte";
 
   type Props = {

--- a/frontend/src/lib/components/ui/task-status/task-status-select.svelte
+++ b/frontend/src/lib/components/ui/task-status/task-status-select.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import { ResponsiveText } from "$lib/components/ui/responsive-text";
-  import type { Status } from "$lib/koso.svelte";
+  import type { Status } from "$lib/yproxy";
   import { TaskStatusIcon } from ".";
 
   const statuses: Status[] = ["Not Started", "In Progress", "Done"];

--- a/frontend/src/lib/dag-table/drop-indicator.svelte
+++ b/frontend/src/lib/dag-table/drop-indicator.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import * as Tooltip from "$lib/components/ui/tooltip";
   import { cn } from "$lib/utils";
-  import type { YTask } from "$lib/yproxy";
+  import type { YTaskProxy } from "$lib/yproxy";
   import { ArrowBigDown } from "lucide-svelte";
 
   type Props = {
-    src: YTask;
-    dest: YTask;
+    src: YTaskProxy;
+    dest: YTaskProxy;
     width: number;
     offset: number;
     type: "Peer" | "Child";

--- a/frontend/src/lib/dag-table/drop-indicator.svelte
+++ b/frontend/src/lib/dag-table/drop-indicator.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import * as Tooltip from "$lib/components/ui/tooltip";
-  import type { Task } from "$lib/koso.svelte";
   import { cn } from "$lib/utils";
+  import type { YTask } from "$lib/yproxy";
   import { ArrowBigDown } from "lucide-svelte";
 
   type Props = {
-    src: Task;
-    dest: Task;
+    src: YTask;
+    dest: YTask;
     width: number;
     offset: number;
     type: "Peer" | "Child";

--- a/frontend/src/lib/dag-table/link-panel.svelte
+++ b/frontend/src/lib/dag-table/link-panel.svelte
@@ -30,7 +30,7 @@
   );
 
   function link(taskId: string) {
-    koso.linkTask(node.name, taskId, koso.getChildCount(taskId));
+    koso.link(node.name, taskId, koso.getChildCount(taskId));
     query = "";
     open = false;
   }

--- a/frontend/src/lib/dag-table/link-panel.svelte
+++ b/frontend/src/lib/dag-table/link-panel.svelte
@@ -19,7 +19,8 @@
   let query = $state("");
   let tasks = $derived(
     open
-      ? Array.from(koso.graph.tasks())
+      ? koso
+          .getTasks()
           .filter((task) => match(task.num, query) || match(task.name, query))
           .filter((task) => task.id !== "root")
           .filter((task) => koso.canLink(node.name, task.id))

--- a/frontend/src/lib/dag-table/link-panel.svelte
+++ b/frontend/src/lib/dag-table/link-panel.svelte
@@ -19,11 +19,12 @@
   let query = $state("");
   let tasks = $derived(
     open
-      ? Object.values(koso.graph)
+      ? Array.from(koso.graph.tasks())
           .filter((task) => match(task.num, query) || match(task.name, query))
           .filter((task) => task.id !== "root")
           .filter((task) => koso.canLink(node.name, task.id))
           .sort((t1, t2) => t2.children.length - t1.children.length)
+          .slice(0, 50)
       : [],
   );
 

--- a/frontend/src/lib/dag-table/row.svelte
+++ b/frontend/src/lib/dag-table/row.svelte
@@ -240,7 +240,7 @@
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverPeer = true;
-    } else if (koso.canMove(koso.dragged, node.parent)) {
+    } else if (koso.canMoveNode(koso.dragged, node.parent)) {
       dataTransfer.dropEffect = "move";
       koso.dropEffect = "move";
       dragOverPeer = true;
@@ -261,7 +261,7 @@
       koso.dropEffect = event.altKey ? "copy" : "move";
       dataTransfer.dropEffect = koso.dropEffect;
       dragOverChild = true;
-    } else if (koso.canMove(koso.dragged, node)) {
+    } else if (koso.canMoveNode(koso.dragged, node)) {
       dataTransfer.dropEffect = "move";
       koso.dropEffect = "move";
       dragOverChild = true;

--- a/frontend/src/lib/koso.svelte.ts
+++ b/frontend/src/lib/koso.svelte.ts
@@ -366,7 +366,6 @@ export class Koso {
   }
 
   // composable functions that primarily operate on Tasks
-  // function should be private if it should be used in a transaction
 
   toJSON(): { [id: string]: Task } {
     return this.graph.toJSON();
@@ -429,7 +428,7 @@ export class Koso {
     return !this.#hasCycle(parent, task) && !this.hasChild(parent, task);
   }
 
-  #link(task: string, parent: string, offset: number) {
+  link(task: string, parent: string, offset: number) {
     if (this.#hasCycle(parent, task)) {
       throw new Error(`Inserting ${task} under ${parent} introduces a cycle`);
     }
@@ -439,12 +438,6 @@ export class Koso {
     }
 
     this.getChildren(parent).insert(offset, [task]);
-  }
-
-  link(task: string, parent: string, offset: number) {
-    this.doc.transact(() => {
-      this.#link(task, parent, offset);
-    });
   }
 
   canMove(task: string, src: string, dest: string): boolean {
@@ -612,7 +605,7 @@ export class Koso {
       if (srcParentName === parent.name && srcOffset < offset) {
         offset -= 1;
       }
-      this.#link(node.name, parent.name, offset);
+      this.link(node.name, parent.name, offset);
     });
     this.selected = parent.child(node.name);
   }
@@ -896,7 +889,7 @@ export class Koso {
         status: null,
         statusTime: null,
       });
-      this.#link(taskId, parent.name, offset);
+      this.link(taskId, parent.name, offset);
     });
     const node = parent.child(taskId);
     this.selected = node;

--- a/frontend/src/lib/koso.svelte.ts
+++ b/frontend/src/lib/koso.svelte.ts
@@ -447,7 +447,11 @@ export class Koso {
     });
   }
 
-  // composable functions that operate on Nodes
+  canMove(task: string, src: string, dest: string): boolean {
+    return src === dest || this.canLink(task, dest);
+  }
+
+  // business logic that operate on Nodes
 
   canExpand(node: Node) {
     return !this.expanded.contains(node) && this.getChildCount(node.name) > 0;
@@ -589,17 +593,15 @@ export class Koso {
     this.link(node.name, parent.name, offset);
   }
 
-  canMove(node: Node, parent: Node): boolean {
-    return (
-      node.parent.name === parent.name || this.canLink(node.name, parent.name)
-    );
+  canMoveNode(node: Node, parent: Node): boolean {
+    return this.canMove(node.name, node.parent.name, parent.name);
   }
 
   moveNode(node: Node, parent: Node, offset: number) {
     if (offset < 0) {
       throw new Error(`Cannot move  ${node.name} to negative offset ${offset}`);
     }
-    if (!this.canMove(node, parent))
+    if (!this.canMoveNode(node, parent))
       throw new Error(`Cannot move ${node.name} to ${parent}`);
     const srcOffset = this.getOffset(node);
     this.doc.transact(() => {
@@ -634,7 +636,7 @@ export class Koso {
           `Trying to move up: newParent: ${newParent.id}, offset: ${newOffset}`,
         );
       }
-      if (!this.canMove(node, newParent)) {
+      if (!this.canMoveNode(node, newParent)) {
         attempts++;
         return false;
       }
@@ -726,7 +728,7 @@ export class Koso {
           `Trying to move down: newParent: ${newParent.id}, offset: ${newOffset}`,
         );
       }
-      if (!this.canMove(node, newParent)) {
+      if (!this.canMoveNode(node, newParent)) {
         attempts++;
         return false;
       }
@@ -837,7 +839,7 @@ export class Koso {
 
   canIndentNode(node: Node): boolean {
     const peer = this.getPrevPeer(node);
-    return !!peer && this.canMove(node, peer);
+    return !!peer && this.canMoveNode(node, peer);
   }
 
   indentNode(node: Node) {
@@ -850,7 +852,7 @@ export class Koso {
 
   canUndentNode(node: Node): boolean {
     if (node.length < 2) return false;
-    return this.canMove(node, node.parent.parent);
+    return this.canMoveNode(node, node.parent.parent);
   }
 
   undentNode(node: Node) {

--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -41,7 +41,7 @@ describe("Koso tests", () => {
     it("retrieves task 2", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 2");
-      expect(koso.getTask(id2.name)).toStrictEqual({
+      expect(koso.getTask(id2.name).toJSON()).toStrictEqual({
         id: id2.name,
         num: "2",
         name: "Task 2",
@@ -64,13 +64,13 @@ describe("Koso tests", () => {
     it("retrieves task 1's children", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 2");
-      expect(koso.getChildren(id1.name)).toStrictEqual([id2.name]);
+      expect(koso.getChildren(id1.name).toJSON()).toStrictEqual([id2.name]);
     });
 
     it("retrieves empty list of children for leaf task", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
       const id2 = koso.insertNode(id1, 0, USER, "Task 2");
-      expect(koso.getChildren(id2.name)).toStrictEqual([]);
+      expect(koso.getChildren(id2.name).toJSON()).toStrictEqual([]);
     });
 
     it("invalid task id throws an exception", () => {
@@ -92,7 +92,7 @@ describe("Koso tests", () => {
 
     it("doc with non-visible tasks still returns root", () => {
       const id1 = koso.insertNode(root, 0, USER, "Task 1");
-      koso.yGraph.get(id1.name)?.set("status", "Done");
+      koso.getTask(id1.name).status = "Done";
       expect(koso.nodes).toStrictEqual(List([root]));
     });
 

--- a/frontend/src/lib/yproxy.ts
+++ b/frontend/src/lib/yproxy.ts
@@ -1,0 +1,210 @@
+import * as Y from "yjs";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type YEvent = Y.YEvent<any>;
+export type YTaskProps = Y.Array<string> | string | number | null;
+
+export type Graph = { [id: string]: Task };
+export type Task = {
+  id: string;
+  num: string;
+  name: string;
+  children: string[];
+  assignee: string | null;
+  reporter: string | null;
+  status: Status | null;
+  // Time, in milliseconds since the unix epoch,
+  // when the `status` field was last modified.
+  statusTime: number | null;
+};
+export type Status = "Not Started" | "In Progress" | "Done";
+
+export class YGraph {
+  #yGraph: Y.Map<Y.Map<YTaskProps>>;
+
+  constructor(yGraph: Y.Map<Y.Map<YTaskProps>>) {
+    this.#yGraph = yGraph;
+  }
+
+  get size() {
+    return this.#yGraph.size;
+  }
+
+  taskIds(): IterableIterator<string> {
+    return this.#yGraph.keys();
+  }
+
+  *tasks(): IterableIterator<YTask> {
+    for (const taskId of this.taskIds()) {
+      yield this.get(taskId);
+    }
+  }
+
+  delete(taskId: string) {
+    this.#yGraph.delete(taskId);
+  }
+
+  set(task: Task): YTask {
+    const newTask = new Y.Map<YTaskProps>([
+      ["id", task.id],
+      ["num", task.num],
+      ["name", task.name],
+      ["children", Y.Array.from(task.children)],
+      ["reporter", task.reporter],
+      ["assignee", task.assignee],
+      ["status", task.status],
+      ["statusTime", task.statusTime],
+    ]);
+    this.#yGraph.set(task.id, newTask);
+    return new YTask(newTask);
+  }
+
+  has(taskId: string): boolean {
+    return this.#yGraph.has(taskId);
+  }
+
+  get(taskId: string): YTask {
+    const yTask = this.#yGraph.get(taskId);
+    if (!yTask) throw new Error(`Unknown Task ID: ${taskId}`);
+    return new YTask(yTask);
+  }
+
+  toJSON(): Graph {
+    return this.#yGraph.toJSON();
+  }
+
+  observe(f: (arg0: YEvent[], arg1: Y.Transaction) => void) {
+    this.#yGraph.observeDeep(f);
+  }
+
+  unobserve(f: (arg0: YEvent[], arg1: Y.Transaction) => void) {
+    this.#yGraph.unobserveDeep(f);
+  }
+}
+
+export class YTask {
+  #yTask: Y.Map<YTaskProps>;
+
+  constructor(yTask: Y.Map<YTaskProps>) {
+    this.#yTask = yTask;
+  }
+
+  get id(): string {
+    return this.#yTask.get("id") as string;
+  }
+
+  get num(): string {
+    return this.#yTask.get("num") as string;
+  }
+
+  set num(value: string) {
+    this.#yTask.set("num", value);
+  }
+
+  get name(): string {
+    return this.#yTask.get("name") as string;
+  }
+
+  set name(value: string) {
+    this.#yTask.set("name", value);
+  }
+
+  get children(): YChildren {
+    const yChildren = this.#yTask.get("children") as Y.Array<string>;
+    if (!yChildren) throw new Error("yChildren is undefined");
+    return new YChildren(yChildren);
+  }
+
+  get assignee(): string | null {
+    return (this.#yTask.get("assignee") as string) || null;
+  }
+
+  set assignee(value: string | null) {
+    this.#yTask.set("assignee", value);
+  }
+
+  get reporter(): string | null {
+    return (this.#yTask.get("reporter") as string) || null;
+  }
+
+  set reporter(value: string | null) {
+    this.#yTask.set("reporter", value);
+  }
+
+  get status(): Status | null {
+    return (this.#yTask.get("status") as Status) || null;
+  }
+
+  set status(value: Status | null) {
+    this.#yTask.set("status", value);
+  }
+
+  get statusTime(): number | null {
+    return (this.#yTask.get("statusTime") as number) || null;
+  }
+
+  set statusTime(value: number | null) {
+    this.#yTask.set("statusTime", value);
+  }
+
+  toJSON(): Task {
+    return this.#yTask.toJSON() as Task;
+  }
+}
+
+export class YChildren {
+  #yChildren: Y.Array<string>;
+
+  constructor(yChildren: Y.Array<string>) {
+    this.#yChildren = yChildren;
+  }
+
+  get length(): number {
+    return this.#yChildren.length;
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.#yChildren;
+  }
+
+  get(index: number): string {
+    return this.#yChildren.get(index);
+  }
+
+  slice(start?: number | undefined, end?: number | undefined): string[] {
+    return this.#yChildren.slice(start, end);
+  }
+
+  insert(index: number, content: string[]) {
+    this.#yChildren.insert(index, content);
+  }
+
+  push(content: string[]) {
+    this.#yChildren.push(content);
+  }
+
+  delete(index: number, length?: number) {
+    this.#yChildren.delete(index, length);
+  }
+
+  indexOf(content: string): number {
+    for (let i = 0; i < this.length; i++) {
+      if (this.get(i) === content) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  forEach(f: (arg0: string, arg1: number, arg2: Y.Array<string>) => void) {
+    this.#yChildren.forEach(f);
+  }
+
+  toArray(): string[] {
+    return this.#yChildren.toArray();
+  }
+
+  toJSON(): string[] {
+    return this.#yChildren.toJSON();
+  }
+}

--- a/frontend/src/lib/yproxy.ts
+++ b/frontend/src/lib/yproxy.ts
@@ -48,7 +48,7 @@ export class YGraphProxy {
   }
 
   set(task: Task): YTaskProxy {
-    const newTask = new Y.Map<YTaskProps>([
+    const value = new Y.Map<YTaskProps>([
       ["id", task.id],
       ["num", task.num],
       ["name", task.name],
@@ -58,8 +58,8 @@ export class YGraphProxy {
       ["status", task.status],
       ["statusTime", task.statusTime],
     ]);
-    this.#yGraph.set(task.id, newTask);
-    return new YTaskProxy(newTask);
+    this.#yGraph.set(task.id, value);
+    return new YTaskProxy(value);
   }
 
   has(taskId: string): boolean {

--- a/frontend/src/lib/yproxy.ts
+++ b/frontend/src/lib/yproxy.ts
@@ -199,6 +199,10 @@ export class YChildrenProxy {
     return -1;
   }
 
+  includes(content: string): boolean {
+    return this.indexOf(content) !== -1;
+  }
+
   forEach(f: (arg0: string, arg1: number, arg2: YChildren) => void) {
     this.#yChildren.forEach(f);
   }

--- a/frontend/tests/dag-table-test.ts
+++ b/frontend/tests/dag-table-test.ts
@@ -31,7 +31,7 @@ test.describe("dag table tests", () => {
 
   async function init(page: Page, tasks: TaskBuilder[]) {
     await page.evaluate((tasks) => {
-      window.koso.yDoc.transact(() => {
+      window.koso.doc.transact(() => {
         for (const {
           id,
           num = id,
@@ -42,7 +42,7 @@ test.describe("dag table tests", () => {
           status = null,
           statusTime = null,
         } of tasks) {
-          window.koso.graph.set({
+          window.koso.upsert({
             id,
             num,
             name,
@@ -1211,7 +1211,7 @@ test.describe("dag table tests", () => {
         { id: "2" },
       ]);
       page.evaluate(() => {
-        window.koso.yUndoManager.captureTimeout = 0;
+        window.koso.undoManager.captureTimeout = 0;
       });
 
       await page.getByRole("button", { name: "Task 2 Drag Handle" }).click();
@@ -1250,7 +1250,7 @@ test.describe("dag table tests", () => {
         { id: "1" },
       ]);
       page.evaluate(() => {
-        window.koso.yUndoManager.captureTimeout = 0;
+        window.koso.undoManager.captureTimeout = 0;
       });
 
       await page.getByRole("button", { name: "Task 1 Drag Handle" }).click();

--- a/frontend/tests/dag-table-test.ts
+++ b/frontend/tests/dag-table-test.ts
@@ -1,4 +1,4 @@
-import type { Status } from "$lib/koso.svelte";
+import type { Status } from "$lib/yproxy";
 import { expect, test, type Page } from "@playwright/test";
 import {
   getKosoGraph,
@@ -42,7 +42,7 @@ test.describe("dag table tests", () => {
           status = null,
           statusTime = null,
         } of tasks) {
-          window.koso.upsert({
+          window.koso.graph.set({
             id,
             num,
             name,

--- a/frontend/tests/utils.ts
+++ b/frontend/tests/utils.ts
@@ -8,6 +8,7 @@ export async function getKosoGraph(page: Page): Promise<Graph> {
 export async function getKosoProjectId(page: Page): Promise<Graph> {
   return page.evaluate("koso.projectId");
 }
+
 export async function clear(page: Page) {
   await page.evaluate("koso.clear()");
   await page.reload();

--- a/frontend/tests/utils.ts
+++ b/frontend/tests/utils.ts
@@ -1,4 +1,4 @@
-import type { Graph } from "$lib/koso.svelte";
+import type { Graph } from "$lib/yproxy";
 import { expect, request, type Page } from "@playwright/test";
 
 export async function getKosoGraph(page: Page): Promise<Graph> {


### PR DESCRIPTION
This PR creates wrapper classes (proxies) for YGraph, YTask, and YChildren. These proxies wrap an underlying yjs type and enables us to provide nicer helper functions directly in the proxies. This should allows us to avoid converting the yjs types to JavaScript native objects just to access some method, like indexOf on an array.

The following proxies now exist:

| Proxy | Proxy'd Type | JSON Type | Description |
| --- | --- | --- | --- |
| `YGraph` | `Y.Map<Y.Map<YTaskProps>>` | `{[id: string]: Task}` | The top level graph |
| `YTask` | `Y.Map<YTaskProps>` | `{id: string, num: string, ...}` | A representation of a task |
| `YChildren` | `Y.Array<string>` | `string[]` | List of children IDs |