### PR TITLE
Add colon to the list of split tokens

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -46,6 +46,10 @@ describe("utils tests", () => {
     it("multiple prefixes of multiple words in an email matches", () => {
       expect(match("my.email@gmail.com", "gmail email my")).toBeTruthy();
     });
+
+    it("prefix of title following task tag matches", () => {
+      expect(match("Reliability:Break everything", "Break")).toBeTruthy();
+    });
   });
 
   describe("findEntryIndex", () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -41,7 +41,7 @@ export function findEntryIndex<T, U>(
  * @returns `true` if the text matches the prefix, `false` otherwise.
  */
 export function match(text: string, prefix: string): boolean {
-  const TOKEN_SPLITTER = /[\s.,!?;@]/;
+  const TOKEN_SPLITTER = /[\s.,!?;:@]/;
   const textLower = text.toLocaleLowerCase();
   const prefixLower = prefix.toLocaleLowerCase();
 


### PR DESCRIPTION
Tasks use colons as separators in names