### PR TITLE
Fix flaky tests

### DIFF
--- a/frontend/src/lib/koso.test.ts
+++ b/frontend/src/lib/koso.test.ts
@@ -5,6 +5,7 @@ import * as Y from "yjs";
 import { type TaskBuilder } from "../../tests/utils";
 import type { User } from "./auth.svelte";
 import { Koso, Node } from "./koso.svelte";
+import { uuidv4 } from "lib0/random.js";
 
 const USER: User = {
   email: "t@koso.app",
@@ -65,7 +66,7 @@ describe("Koso tests", () => {
   };
 
   beforeEach(() => {
-    koso = new Koso("project-id", new Y.Doc());
+    koso = new Koso("project-id-" + uuidv4(), new Y.Doc());
     koso.handleClientMessage(() => {});
     koso.handleServerMessage(EMPTY_SYNC_RESPONSE);
   });

--- a/frontend/tests/utils.ts
+++ b/frontend/tests/utils.ts
@@ -64,8 +64,9 @@ export async function setupNewProject(page: Page): Promise<Page> {
 
   await page.goto("/projects");
   await page.getByRole("button", { name: "New" }).click();
+  // Make sure things are initialized before proceeding
   await expect(
-    page.getByRole("button", { name: "Set Project Name" }),
+    await page.getByRole("button", { name: "Add Task" }),
   ).toBeVisible();
 
   return page;


### PR DESCRIPTION
* Use a different project id for each project to avoid accidentally sharing local state, like indexed db
* Wait for koso to be ready before continuing with initialization. This avoids transacting on a doc in init before things are ready