### PR TITLE
Avoid throwing on doc updates when operating in offline mode

### DIFF
--- a/frontend/src/lib/koso.svelte.ts
+++ b/frontend/src/lib/koso.svelte.ts
@@ -87,7 +87,10 @@ export class Koso {
   #yUndoManager: Y.UndoManager;
   #yIndexedDb: IndexeddbPersistence;
   #clientMessageHandler: (message: Uint8Array) => void = () => {
-    throw new Error("Client message handler was invoked but was not set");
+    // Until we connect to the server and invoke handleClientMessage,
+    // there's nothing else to do with client messages, so we simply discard them.
+    // Any dropped changes will be sync'd to the server later.
+    console.debug("Client message handler was invoked but was not set");
   };
 
   #selected: Node | null = $state(null);


### PR DESCRIPTION
When loading the page in offline mode, no socket will have opened successfully and thus no clientMessageHandler will be set. Doc modifications trigger the on-update observer which calls #clientMessageHandler and in turn throws.

There isn't much we can do other than emit a debug log and move on. The update will be persisted to indexed DB and sync'd on next connect.