### PR TITLE
Introduce and wire up Rust yproxy for interacting with yrs Doc

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "similar",
  "sqlx",
  "test-log",
  "tokio",
@@ -1994,6 +1995,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -48,6 +48,7 @@ dashmap = "6.1.0"
 anyhow = "1.0.92"
 rand = "0.8.5"
 tower = "0.5.1"
+similar = "2.6.0"
 
 [dev-dependencies]
 test-log = { version = "0.2.16", features = ["trace", "color"] }

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -16,6 +16,7 @@ pub(crate) mod model;
 pub(crate) mod projects;
 pub(crate) mod users;
 pub(crate) mod ws;
+pub(crate) mod yproxy;
 
 pub(crate) type ApiResult<T> = Result<T, ErrorResponse>;
 

--- a/backend/src/api/collab/projects_state.rs
+++ b/backend/src/api/collab/projects_state.rs
@@ -156,10 +156,10 @@ impl ProjectsState {
     }
 }
 
-pub(super) struct ProjectState {
-    pub(super) project_id: ProjectId,
+pub(crate) struct ProjectState {
+    pub(crate) project_id: ProjectId,
     clients: Mutex<HashMap<String, ClientSender>>,
-    doc_box: Mutex<Option<DocBox>>,
+    pub(crate) doc_box: Mutex<Option<DocBox>>,
     updates: atomic::AtomicUsize,
     doc_update_tx: Sender<DocUpdate>,
     pool: &'static PgPool,
@@ -316,8 +316,8 @@ impl Drop for ProjectState {
     }
 }
 
-struct DocBox {
-    doc: Doc,
+pub(crate) struct DocBox {
+    pub(crate) doc: Doc,
     /// Subscription to observe changes to doc.
     #[allow(dead_code)]
     sub: Box<dyn Send>,

--- a/backend/src/api/model.rs
+++ b/backend/src/api/model.rs
@@ -70,5 +70,6 @@ pub(crate) struct Task {
     pub(crate) assignee: Option<String>,
     pub(crate) reporter: Option<String>,
     pub(crate) status: Option<String>,
+    #[serde(rename(serialize = "statusTime", deserialize = "statusTime"))]
     pub(crate) status_time: Option<i64>,
 }

--- a/backend/src/api/model.rs
+++ b/backend/src/api/model.rs
@@ -53,7 +53,7 @@ pub(crate) struct User {
     pub(crate) picture: String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
 pub(crate) struct ProjectExport {
     pub(crate) project_id: ProjectId,
     pub(crate) graph: Graph,
@@ -61,7 +61,7 @@ pub(crate) struct ProjectExport {
 
 pub(crate) type Graph = HashMap<String, Task>;
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug)]
 pub(crate) struct Task {
     pub(crate) id: String,
     pub(crate) num: String,

--- a/backend/src/api/model.rs
+++ b/backend/src/api/model.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 pub(crate) type ProjectId = String;
 
@@ -11,7 +11,7 @@ pub(crate) struct Project {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub(crate) struct CreateProject {
     pub(crate) name: String,
-    pub(crate) import_data: Option<String>,
+    pub(crate) import_data: Option<ProjectExport>,
 }
 
 impl fmt::Debug for CreateProject {
@@ -56,5 +56,19 @@ pub(crate) struct User {
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub(crate) struct ProjectExport {
     pub(crate) project_id: ProjectId,
-    pub(crate) data: yrs::Any,
+    pub(crate) graph: Graph,
+}
+
+pub(crate) type Graph = HashMap<String, Task>;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub(crate) struct Task {
+    pub(crate) id: String,
+    pub(crate) num: String,
+    pub(crate) name: String,
+    pub(crate) children: Vec<String>,
+    pub(crate) assignee: Option<String>,
+    pub(crate) reporter: Option<String>,
+    pub(crate) status: Option<String>,
+    pub(crate) status_time: Option<i64>,
 }

--- a/backend/src/api/projects.rs
+++ b/backend/src/api/projects.rs
@@ -4,7 +4,7 @@ use crate::{
         collab::{storage, Collab},
         google::User,
         model::{
-            CreateProject, Graph, Project, ProjectExport, ProjectUser, UpdateProjectUsers,
+            CreateProject, Project, ProjectExport, ProjectUser, UpdateProjectUsers,
             UpdateProjectUsersResponse,
         },
         verify_access,
@@ -32,7 +32,6 @@ pub(super) fn router() -> Router {
         .route("/:project_id", patch(update_project_handler))
         .route("/:project_id/users", patch(update_project_users_handler))
         .route("/:project_id/users", get(list_project_users_handler))
-        .route("/:project_id/doc", get(get_project_doc_handler))
         .route("/:project_id/updates", get(get_project_doc_updates_handler))
         .route("/:project_id/export", get(export_project))
 }
@@ -254,17 +253,6 @@ async fn update_project_users_handler(
     txn.commit().await?;
 
     Ok(Json(UpdateProjectUsersResponse {}))
-}
-
-#[tracing::instrument(skip(user, pool, collab))]
-async fn get_project_doc_handler(
-    Extension(user): Extension<User>,
-    Extension(pool): Extension<&'static PgPool>,
-    Extension(collab): Extension<Collab>,
-    Path(project_id): Path<String>,
-) -> ApiResult<Json<Graph>> {
-    verify_access(pool, user, &project_id).await?;
-    Ok(Json(collab.get_graph(&project_id).await?))
 }
 
 #[tracing::instrument(skip(user, pool))]

--- a/backend/src/api/projects.rs
+++ b/backend/src/api/projects.rs
@@ -3,7 +3,10 @@ use crate::{
         bad_request_error,
         collab::{storage, Collab},
         google::User,
-        model::{CreateProject, Project, ProjectUser, UpdateProjectUsers},
+        model::{
+            CreateProject, Graph, Project, ProjectExport, ProjectUser, UpdateProjectUsers,
+            UpdateProjectUsersResponse,
+        },
         verify_access,
         yproxy::YGraphProxy,
         ApiResult,
@@ -20,8 +23,6 @@ use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use sqlx::postgres::PgPool;
 use uuid::Uuid;
 use yrs::{Doc, ReadTxn as _, StateVector, Transact as _};
-
-use super::model::{Graph, ProjectExport, UpdateProjectUsersResponse};
 
 pub(super) fn router() -> Router {
     Router::new()

--- a/backend/src/api/projects.rs
+++ b/backend/src/api/projects.rs
@@ -20,10 +20,7 @@ use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use sqlx::postgres::PgPool;
 use std::collections::HashMap;
 use uuid::Uuid;
-use yrs::{
-    Any, ArrayPrelim, Doc, In, Map, MapPrelim, ReadTxn as _, StateVector, Transact as _,
-    WriteTxn as _,
-};
+use yrs::{Doc, ReadTxn as _, StateVector, Transact as _};
 
 use super::model::{Graph, ProjectExport, UpdateProjectUsersResponse};
 
@@ -295,9 +292,7 @@ async fn export_project(
 ) -> ApiResult<Json<ProjectExport>> {
     verify_access(pool, user, &project_id).await?;
 
-    let doc = collab.get_doc(&project_id).await?;
-    let mut graph = HashMap::new();
-    // TODO
+    let graph = collab.get_graph(&project_id).await?;
     Ok(Json(ProjectExport { project_id, graph }))
 }
 

--- a/backend/src/api/projects.rs
+++ b/backend/src/api/projects.rs
@@ -18,7 +18,6 @@ use axum::{
 };
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use sqlx::postgres::PgPool;
-use std::collections::HashMap;
 use uuid::Uuid;
 use yrs::{Doc, ReadTxn as _, StateVector, Transact as _};
 

--- a/backend/src/api/yproxy.rs
+++ b/backend/src/api/yproxy.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use anyhow::Result;
+use yrs::Out;
+use yrs::{Any, ArrayPrelim, Doc, In, Map, MapPrelim, MapRef, ReadTxn, Transact, WriteTxn};
+
+pub(crate) struct Task<'a> {
+    id: &'a str,
+    num: &'a str,
+    name: &'a str,
+    children: Vec<&'a str>,
+    assignee: Option<&'a str>,
+    reporter: Option<&'a str>,
+    status: Option<&'a str>,
+    status_time: Option<i64>,
+}
+
+pub(crate) struct YDocProxy<'a> {
+    doc: &'a Doc,
+}
+
+impl<'a> YDocProxy<'a> {
+    pub fn transact(&self) -> YGraphProxy<'a> {
+        let txn: yrs::TransactionMut<'a> = self.doc.transact_mut();
+        YGraphProxy { txn }
+    }
+}
+
+pub(crate) struct YGraphProxy<'a> {
+    txn: yrs::TransactionMut<'a>,
+}
+
+impl<'a> YGraphProxy<'a> {
+    fn graph(&mut self) -> MapRef {
+        self.txn.get_or_insert_map("graph")
+    }
+
+    pub fn size(&mut self) -> u32 {
+        self.graph().len(&self.txn)
+    }
+
+    pub fn set(&mut self, task: &Task) {
+        let mut y_task: HashMap<String, In> = HashMap::new();
+
+        y_task.insert("id".into(), task.id.into());
+        y_task.insert("num".into(), task.num.into());
+        y_task.insert("name".into(), task.name.into());
+        y_task.insert(
+            "children".into(),
+            In::Array(ArrayPrelim::from(task.children.clone())),
+        );
+        y_task.insert("assignee".into(), or_else_null(task.assignee));
+        y_task.insert("reporter".into(), or_else_null(task.reporter));
+        y_task.insert("status".into(), or_else_null(task.status));
+        y_task.insert("statusTime".into(), or_else_null(task.status_time));
+
+        self.graph()
+            .insert(&mut self.txn, task.id, MapPrelim::from_iter(y_task));
+    }
+
+    pub fn has(&mut self, id: &str) -> bool {
+        let graph = self.txn.get_or_insert_map("graph");
+        let result = graph.get(&self.txn, id);
+        result.is_some()
+    }
+
+    pub fn get(&'a mut self, id: &str) -> Result<YTaskProxy<'a>> {
+        let Some(y_task) = self.graph().get(&self.txn, id) else {
+            return Err(anyhow!("task is missing: {id}"));
+        };
+        let y_task = match y_task {
+            Out::YMap(map_ref) => map_ref,
+            _ => return Err(anyhow!("task {id} is not a map")),
+        };
+        Ok(YTaskProxy {
+            txn: &self.txn,
+            y_task,
+        })
+    }
+}
+
+pub(crate) struct YTaskProxy<'a> {
+    txn: &'a yrs::TransactionMut<'a>,
+    y_task: MapRef,
+}
+
+impl<'a> YTaskProxy<'a> {
+    fn get_optional_string(self, field: &str) -> Result<Option<Arc<str>>> {
+        let Some(result) = self.y_task.get(self.txn, field) else {
+            return Ok(None);
+        };
+        let Out::Any(Any::String(result)) = result else {
+            return Err(anyhow!("invalid field: {field}: {result}"));
+        };
+        Ok(Some(result))
+    }
+
+    fn get_string(self, field: &str) -> Result<Arc<str>> {
+        let Some(result) = self.get_optional_string(field)? else {
+            return Err(anyhow!("field is missing: {field}"));
+        };
+        Ok(result)
+    }
+
+    pub fn get_id(self) -> Result<Arc<str>> {
+        self.get_string("id")
+    }
+
+    pub fn get_num(self) -> Result<Arc<str>> {
+        self.get_string("num")
+    }
+
+    pub fn get_name(self) -> Result<Arc<str>> {
+        self.get_string("name")
+    }
+
+    pub fn get_assignee(self) -> Result<Option<Arc<str>>> {
+        self.get_optional_string("assignee")
+    }
+
+    pub fn get_reporter(self) -> Result<Option<Arc<str>>> {
+        self.get_optional_string("reporter")
+    }
+
+    pub fn get_status(self) -> Result<Option<Arc<str>>> {
+        self.get_optional_string("status")
+    }
+
+    pub fn get_status_time(self, field: &str) -> Result<Option<f64>> {
+        let Some(result) = self.y_task.get(self.txn, field) else {
+            return Ok(None);
+        };
+        let Out::Any(Any::Number(result)) = result else {
+            return Err(anyhow!("invalid field: {field}: {result}"));
+        };
+        Ok(Some(result))
+    }
+}
+
+fn or_else_null<T>(v: Option<T>) -> In
+where
+    T: Into<In>,
+{
+    v.map(|v| v.into()).unwrap_or(Any::Null.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use yrs::{types::ToJson, Transact};
+
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let doc = Doc::new();
+
+        {
+            let y_doc = YDocProxy { doc: &doc };
+            let mut y_graph = y_doc.transact();
+            y_graph.set(&Task {
+                id: "1",
+                num: "1",
+                name: "Task 1",
+                children: vec!["2"],
+                assignee: Some("assigneed@gmail.com"),
+                reporter: Some("reporter@gmail.com"),
+                status: Some("Done"),
+                status_time: Some(23),
+            });
+        }
+
+        let graph = doc
+            .get_or_insert_map("graph")
+            .get(&doc.transact(), "1")
+            .unwrap()
+            .to_json(&doc.transact());
+        println!("{:?}", graph);
+
+        {
+            let y_doc = YDocProxy { doc: &doc };
+            let mut y_graph = y_doc.transact();
+            let y_task = match y_graph.get("1") {
+                Ok(y_task) => y_task,
+                Err(e) => {
+                    panic!("Error getting task: {e}");
+                }
+            };
+            println!("{:?}", y_task.get_id());
+        }
+    }
+}

--- a/backend/src/api/yproxy.rs
+++ b/backend/src/api/yproxy.rs
@@ -1,22 +1,12 @@
 use std::sync::Arc;
 
+use crate::api::model::Task;
 use anyhow::anyhow;
 use anyhow::Result;
 use similar::capture_diff_slices;
 use similar::Algorithm;
 use yrs::types::ToJson;
 use yrs::{Any, Array, ArrayRef, Map, MapRef, Out, ReadTxn, TransactionMut, WriteTxn};
-
-pub(crate) struct Task {
-    id: String,
-    num: String,
-    name: String,
-    children: Vec<String>,
-    assignee: Option<String>,
-    reporter: Option<String>,
-    status: Option<String>,
-    status_time: Option<i64>,
-}
 
 pub(crate) struct YGraphProxy {
     graph: MapRef,

--- a/frontend/src/lib/projects.ts
+++ b/frontend/src/lib/projects.ts
@@ -1,4 +1,4 @@
-import { parse_response, headers } from "./api";
+import { headers, parse_response } from "./api";
 import { type User } from "./auth.svelte";
 
 export type Project = {
@@ -14,7 +14,7 @@ export type UpdateProjectUsers = {
 
 export type ProjectExport = {
   project_id: string;
-  data: unknown;
+  graph: unknown;
 };
 
 export const COMPARE_USERS_BY_NAME_AND_EMAIL = (a: User, b: User) =>
@@ -37,7 +37,7 @@ export async function fetchProject(projectId: string): Promise<Project> {
 }
 
 export async function createProject(
-  import_data: string | null = null,
+  projectExport: ProjectExport | null = null,
 ): Promise<Project> {
   const response = await fetch("/api/projects", {
     method: "POST",
@@ -45,7 +45,7 @@ export async function createProject(
       ...headers(),
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ name: "My Project!", import_data }),
+    body: JSON.stringify({ name: "My Project!", import_data: projectExport }),
   });
   return parse_response(response);
 }

--- a/frontend/src/routes/(auth)/projects/+page.svelte
+++ b/frontend/src/routes/(auth)/projects/+page.svelte
@@ -26,8 +26,12 @@
       if (err instanceof KosoError && err.hasReason("TOO_MANY_PROJECTS")) {
         errorMessage =
           "Cannot create new project, you already have too many. Contact us for more!";
+      } else if (err instanceof KosoError && err.status === 422) {
+        errorMessage =
+          "The Koso export file is malformed. Verify the correct file was selected and try again.";
       } else {
         errorMessage = "Something went wrong. Please try again.";
+        console.warn(err);
       }
       return;
     }
@@ -75,7 +79,7 @@
 <Navbar />
 
 {#if errorMessage}
-  <div class="my-2 flex-grow-0">
+  <div class="m-4 flex-grow-0">
     <Alert variant="destructive">{errorMessage}</Alert>
   </div>
 {/if}

--- a/frontend/src/routes/(auth)/projects/+page.svelte
+++ b/frontend/src/routes/(auth)/projects/+page.svelte
@@ -9,7 +9,7 @@
     createProject as projectsCreateProject,
     type Project,
   } from "$lib/projects";
-  import { Layers, HardDriveUpload, PackagePlus } from "lucide-svelte";
+  import { HardDriveUpload, Layers, PackagePlus } from "lucide-svelte";
   import { toast } from "svelte-sonner";
 
   let deflicker: Promise<Project[]> = new Promise((r) => setTimeout(r, 50));
@@ -27,6 +27,7 @@
           "Cannot create new project, you already have too many. Contact us for more!";
       } else if (
         err instanceof KosoError &&
+        // TODO: make this work, malformed_import is no longer returned
         err.hasReason("MALFORMED_IMPORT")
       ) {
         errorMessage =

--- a/frontend/tests/import-export-test.ts
+++ b/frontend/tests/import-export-test.ts
@@ -1,11 +1,11 @@
 import { expect, test, type Page } from "@playwright/test";
+import type { Readable } from "stream";
 import {
   getKosoGraph,
   getKosoProjectId,
   setupNewProject,
   tearDown,
 } from "./utils";
-import type { Readable } from "stream";
 
 test.describe.configure({ mode: "parallel" });
 
@@ -35,12 +35,12 @@ test.describe("import export tests", () => {
     // Export the project
     const downloadPromise = download(page);
     await page.getByRole("button", { name: "Export Project" }).click();
-    const exportedProject = await downloadPromise;
-    expect(exportedProject.filename).toContain("export");
-    expect(exportedProject.data["project_id"]).toEqual(
+    const projectExport1 = await downloadPromise;
+    expect(projectExport1.filename).toContain("export");
+    expect(projectExport1.data["project_id"]).toEqual(
       await getKosoProjectId(page),
     );
-    expect(exportedProject.data["data"]).toEqual(await getKosoGraph(page));
+    expect(projectExport1.data["graph"]).toEqual(await getKosoGraph(page));
 
     // Import the project
     await page.goto("/projects");
@@ -48,22 +48,22 @@ test.describe("import export tests", () => {
     await page.getByRole("button", { name: "Import" }).click();
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles({
-      name: exportedProject.filename,
+      name: projectExport1.filename,
       mimeType: "json",
-      buffer: exportedProject.dataBuf,
+      buffer: projectExport1.dataBuf,
     });
     await expect(page.getByRole("row", { name: "Task 1" })).toBeVisible();
 
     // Export the newly imported project.
     const downloadPromise2 = download(page);
     await page.getByRole("button", { name: "Export Project" }).click();
-    const exportedProject2 = await downloadPromise2;
-    expect(exportedProject2.filename).toContain("export");
-    expect(exportedProject2.data["project_id"]).toEqual(
+    const projectExport2 = await downloadPromise2;
+    expect(projectExport2.filename).toContain("export");
+    expect(projectExport2.data["project_id"]).toEqual(
       await getKosoProjectId(page),
     );
-    expect(exportedProject2.data["data"]).toEqual(await getKosoGraph(page));
-    expect(exportedProject2.data["data"]).toEqual(exportedProject.data["data"]);
+    expect(projectExport2.data["graph"]).toEqual(await getKosoGraph(page));
+    expect(projectExport2.data["graph"]).toEqual(projectExport1.data["graph"]);
 
     // Validate that a new task can be created
     await page.getByRole("button", { name: "Insert" }).last().click();


### PR DESCRIPTION
Changes:
- Introduce Rust yproxy objects for interacting with yrs which includes wrappers for the Graph MapRef and the Task MapRef that provide simple type safe getters and setters.
- Setters try to do the optimal mutation. For example, don't do anything at all if the value hasn't changed. This is prominent when mutating children. We use the `similar` library to compute a sequence of mutations that transforms the previous value into the new value.
- Migrate the import and export endpoints to use the new yproxy objects and remove the old doc endpoint which is no longer needed – use the export endpoint instead.
