### PR TITLE
Ensure origin is always set on mutable transactions

### DIFF
--- a/backend/src/api/collab/doc_updates.rs
+++ b/backend/src/api/collab/doc_updates.rs
@@ -179,12 +179,7 @@ impl GraphObserver {
                 }
 
                 let project = project.clone();
-                let origin = from_origin(txn.origin())?;
-                let origin = YOrigin {
-                    who: format!("rw-{}", origin.who),
-                    id: format!("rw-{}", origin.id),
-                    actor: origin.actor,
-                };
+                let origin = from_origin(txn.origin())?.delegated("rw");
                 let mod_id = mod_id.clone();
                 self.tracker.spawn(
                     async move {

--- a/backend/src/api/collab/txn_origin.rs
+++ b/backend/src/api/collab/txn_origin.rs
@@ -9,6 +9,7 @@ pub(crate) enum Actor {
     None,
     User(User),
     GitHub,
+    Server,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -29,5 +30,13 @@ pub(crate) fn from_origin(origin: Option<&Origin>) -> Result<YOrigin> {
 impl YOrigin {
     pub(crate) fn as_origin(&self) -> Result<Origin> {
         Ok(serde_json::to_string(self)?.into())
+    }
+
+    pub(crate) fn delegated(&self, prefix: &str) -> YOrigin {
+        YOrigin {
+            who: format!("{}-{}", prefix, self.who),
+            id: format!("{}-{}", prefix, self.id),
+            actor: Actor::Server,
+        }
     }
 }

--- a/backend/src/api/yproxy.rs
+++ b/backend/src/api/yproxy.rs
@@ -84,10 +84,6 @@ impl YDocProxy {
         self.doc.transact()
     }
 
-    pub fn transact_mut(&self) -> TransactionMut<'_> {
-        self.doc.transact_mut()
-    }
-
     pub fn transact_mut_with<T: Into<Origin>>(&self, origin: T) -> TransactionMut {
         self.doc.transact_mut_with(origin)
     }
@@ -305,14 +301,23 @@ impl YTaskProxy {
 
 #[cfg(test)]
 mod tests {
+    use crate::api::collab::txn_origin::{self, YOrigin};
+
     use super::*;
 
     #[test]
     fn set_and_get_task_succeeds() {
         let ydoc = YDocProxy::new();
+        let origin = YOrigin {
+            who: "set_and_get_task_succeeds".to_string(),
+            id: "test".to_string(),
+            actor: txn_origin::Actor::Server,
+        }
+        .as_origin()
+        .unwrap();
 
         {
-            let mut txn = ydoc.transact_mut();
+            let mut txn = ydoc.transact_mut_with(origin.clone());
             ydoc.set(
                 &mut txn,
                 &Task {
@@ -331,7 +336,7 @@ mod tests {
         }
 
         {
-            let mut txn = ydoc.transact_mut();
+            let mut txn = ydoc.transact_mut_with(origin.clone());
             ydoc.set(
                 &mut txn,
                 &Task {


### PR DESCRIPTION
Our observers count on receiving origins in order to understand the context, origin, of the transaction. Removing the transact_mut method makes it less easy to forget the origin.