### PR TITLE
Use different lib names to avoid name conflicts

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # Target built docker to speed up dependency compilation.
 # See Dockerfile.
 [lib]
-name = "build_dummy"
+name = "build_backend_dummy"
 path = "build/dummy.rs"
 
 [dependencies]

--- a/healthz/Cargo.toml
+++ b/healthz/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 # Target built docker to speed up dependency compilation.
 # See Dockerfile.
 [lib]
-name = "build_dummy"
+name = "build_healthz_dummy"
 path = "build/dummy.rs"
 
 [dependencies]


### PR DESCRIPTION
```
warning: output filename collision.
The lib target `build_dummy` in package `koso v0.1.0 (.../koso/backend)` has the same output filename as the lib target `build_dummy` in package `healthz v0.1.0 (.../koso/healthz)`.
Colliding filename is: .../koso/target/debug/libbuild_dummy.rlib
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```