### PR TITLE
Use exactly name matches to avoid flakes

### DIFF
--- a/frontend/tests/collab-test.ts
+++ b/frontend/tests/collab-test.ts
@@ -81,7 +81,10 @@ test.describe("Collaboration tests", () => {
   });
 
   test("Collaborate to create and delete tasks", async ({ page1, page2 }) => {
-    await page1.getByRole("button", { name: "Add" }).first().click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
 
     await expect(page1.getByRole("row", { name: "Task 1" })).toBeVisible();
     let graph = await getKosoGraph(page1);
@@ -90,7 +93,7 @@ test.describe("Collaboration tests", () => {
     await expect(page2.getByRole("row", { name: "Task 1" })).toBeVisible();
     expect(graph).toStrictEqual(await getKosoGraph(page2));
 
-    await page2.getByRole("button", { name: "Add" }).click();
+    await page2.getByRole("button", { name: "Add", exact: true }).click();
 
     await expect(page2.getByRole("row", { name: "Task 2" })).toBeVisible();
     graph = await getKosoGraph(page2);
@@ -130,9 +133,18 @@ test.describe("Collaboration tests", () => {
     page1,
     page2,
   }) => {
-    await page1.getByRole("button", { name: "Add" }).first().click();
-    await page1.getByRole("button", { name: "Add" }).first().click();
-    await page1.getByRole("button", { name: "Add" }).first().click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
 
     await expect(page1.getByRole("row", { name: "Task 1" })).toBeVisible();
     await expect(page1.getByRole("row", { name: "Task 2" })).toBeVisible();
@@ -171,7 +183,10 @@ test.describe("Collaboration tests", () => {
       window.koso.undoManager.captureTimeout = 0;
     });
 
-    await page1.getByRole("button", { name: "Add" }).first().click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
     await expect(page1.getByRole("row", { name: "Task 1" })).toBeVisible();
     await expect(page2.getByRole("row", { name: "Task 1" })).toBeVisible();
 
@@ -195,7 +210,10 @@ test.describe("Collaboration tests", () => {
       window.koso.undoManager.captureTimeout = 0;
     });
 
-    await page1.getByRole("button", { name: "Add" }).first().click();
+    await page1
+      .getByRole("button", { name: "Add", exact: true })
+      .first()
+      .click();
     await expect(page1.getByRole("row", { name: "Task 1" })).toBeVisible();
     await expect(page2.getByRole("row", { name: "Task 1" })).toBeVisible();
     await page1.keyboard.type("EditedTask");

--- a/frontend/tests/dag-table-test.ts
+++ b/frontend/tests/dag-table-test.ts
@@ -21,7 +21,10 @@ test.describe("dag table tests", () => {
 
   test.describe("creating tasks", () => {
     test("create a task by clicking the Add button", async ({ page }) => {
-      await page.getByRole("button", { name: "Add" }).last().click();
+      await page
+        .getByRole("button", { name: "Add", exact: true })
+        .last()
+        .click();
       await page.keyboard.press("Escape");
 
       await expect(page.getByRole("row", { name: "Task 1" })).toBeFocused();
@@ -35,7 +38,10 @@ test.describe("dag table tests", () => {
     test("create a task by clicking the Add button and then edit", async ({
       page,
     }) => {
-      await page.getByRole("button", { name: "Add" }).last().click();
+      await page
+        .getByRole("button", { name: "Add", exact: true })
+        .last()
+        .click();
 
       await expect(
         page.getByRole("textbox", { name: "Task 1 Edit Name" }),

--- a/frontend/tests/import-export-test.ts
+++ b/frontend/tests/import-export-test.ts
@@ -24,11 +24,11 @@ test.describe("import export tests", () => {
     await page.getByRole("button", { name: "Add Task" }).last().click();
     await expect(page.getByRole("row", { name: "Task 1" })).toBeVisible();
     await page.keyboard.press("Escape");
-    await page.getByRole("button", { name: "Add" }).last().click();
+    await page.getByRole("button", { name: "Add", exact: true }).last().click();
     await page.keyboard.type("Task 2 name");
     await page.keyboard.press("Enter");
     await expect(page.getByRole("row", { name: "Task 2" })).toBeVisible();
-    await page.getByRole("button", { name: "Add" }).click();
+    await page.getByRole("button", { name: "Add", exact: true }).click();
     await page.keyboard.type("Task 3 child name");
     await page.keyboard.press("Enter");
     await expect(page.getByRole("row", { name: "Task 3" })).toBeVisible();
@@ -65,7 +65,7 @@ test.describe("import export tests", () => {
     expect(projectExport2.data.graph).toEqual(projectExport1.data.graph);
 
     // Validate that a new task can be created
-    await page.getByRole("button", { name: "Add" }).last().click();
+    await page.getByRole("button", { name: "Add", exact: true }).last().click();
     await expect(page.getByRole("row", { name: "Task 4" })).toBeVisible();
     await expect(page.getByRole("row", { name: "Task 4" })).toBeFocused;
   });

--- a/frontend/tests/project-test.ts
+++ b/frontend/tests/project-test.ts
@@ -32,7 +32,7 @@ test.describe("project tests", () => {
   });
 
   test("create a project and rename it to Integration Test Project", async () => {
-    await page.getByRole("button", { name: "New" }).click();
+    await page.getByRole("button", { name: "New", exact: true }).click();
 
     await page.getByRole("button", { name: "Set Project Name" }).click();
     await page.keyboard.press("ControlOrMeta+A");

--- a/frontend/tests/utils.ts
+++ b/frontend/tests/utils.ts
@@ -84,7 +84,7 @@ export async function setupNewProject(page: Page): Promise<Page> {
   await login(page, generateEmail());
 
   await page.goto("/projects");
-  await page.getByRole("button", { name: "New" }).click();
+  await page.getByRole("button", { name: "New", exact: true }).click();
   // Make sure things are initialized before proceeding
   await expect(page.getByRole("button", { name: "Add Task" })).toBeVisible();
 


### PR DESCRIPTION
https://github.com/kosolabs/koso/actions/runs/14315579544/attempts/1

This'll fix errors like the following where a generated button happenes to contain a short substring "add"


```
1) tests/dag-table-test.ts:1124:7 › dag table tests › moving tasks › within contiguous groups › all tasks same status moves task to the bottom 

    Error: locator.click: Error: strict mode violation: getByRole('button', { name: 'New' }) resolved to 2 elements:
        1) <button aria-haspopup="menu" aria-expanded="false" title="49new7l71at-1744046880239-test@test.koso.app" class="focus-visible:outline-m3-primary focus-visible:outline-1">…</button> aka getByRole('button', { name: '49new7l71at-1744046880239-' })
        2) <button class="shadow-m3-shadow/20 disabled:text-m3-on-surface/38 disabled:bg-m3-on-surface/12 disabled:cursor-not-allowed rounded-md focus:ring-1 focus-visible:outline-hidden ring-1 text-m3-primary focus:ring-m3-primary enabled:hover:bg-m3-primary/15 focus:bg-m3-primary/15 flex items-center gap-2 text-sm text-nowrap transition-all enabled:active:scale-95 px-4 py-1.5">…</button> aka getByRole('button', { name: 'New', exact: true })

    Call log:
      - waiting for getByRole('button', { name: 'New' })


       at utils.ts:87

      85 |
      86 |   await page.goto("/projects");
    > 87 |   await page.getByRole("button", { name: "New" }).click();
         |                                                   ^
      88 |   // Make sure things are initialized before proceeding
      89 |   await expect(page.getByRole("button", { name: "Add Task" })).toBeVisible();
      90 |
        at setupNewProject (/home/runner/work/koso/koso/frontend/tests/utils.ts:87:51)
        at /home/runner/work/koso/koso/frontend/tests/dag-table-test.ts:15:5

  1 failed
    tests/dag-table-test.ts:1[124](https://github.com/kosolabs/koso/actions/runs/14315579544/job/40120799605#step:14:125):7 › dag table tests › moving tasks › within contiguous groups › all tasks same status moves task to the bottom
 ```