### PR TITLE
Configure panics to abort the process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,9 @@
 
 members = ["backend", "healthz"]
 resolver = "2"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"


### PR DESCRIPTION
Avoid lingering in a potentially incomplete state. For example, background processing tasks may panic, leaving the server effectively not functional. A tradeoff - conceivably, continue processing in the face of a task serving an individual request and avoid a total restart.