### PR TITLE
Add middleware to log request and response bodies in dev mode

### DIFF
--- a/backend/src/debug.rs
+++ b/backend/src/debug.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use axum::{
+    body::Body,
+    extract::Request,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use regex::Regex;
+
+use crate::{api::ApiResult, settings::settings};
+
+const BODY_LIMIT: usize = 10 * 1024 * 1024;
+
+pub(super) async fn log_request_response(
+    request: Request,
+    next: Next,
+) -> ApiResult<impl IntoResponse> {
+    if !matches(&settings().debug_path, &request) {
+        return Ok(next.run(request).await);
+    }
+
+    let request = log_request_body(request).await?;
+    let response = next.run(request).await;
+    let response = log_response_body(response).await?;
+
+    Ok(response)
+}
+
+async fn log_request_body(request: Request) -> Result<Request> {
+    let (parts, body) = request.into_parts();
+    let bytes = axum::body::to_bytes(body, BODY_LIMIT).await?;
+    tracing::debug!("Request: {}", String::from_utf8_lossy(&bytes));
+    Ok(Request::from_parts(parts, Body::from(bytes)))
+}
+
+async fn log_response_body(response: Response) -> Result<Response> {
+    let (parts, body) = response.into_parts();
+    let bytes = axum::body::to_bytes(body, BODY_LIMIT).await?;
+    tracing::debug!("Response: {}", String::from_utf8_lossy(&bytes));
+    Ok(Response::from_parts(parts, Body::from(bytes)))
+}
+
+fn matches(pattern: &Option<Regex>, request: &Request) -> bool {
+    match pattern {
+        Some(pattern) => pattern.is_match(request.uri().path()),
+        None => false,
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,7 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod api;
+mod debug;
 mod healthz;
 mod metrics_server;
 mod notifiers;

--- a/koso.http
+++ b/koso.http
@@ -1,3 +1,10 @@
+GET http://localhost:3000/healthz
+Content-Type: application/json
+###
+GET http://localhost:3000/api/profile
+Content-Type: application/json
+Authorization: Bearer {{token}}
+###
 GET http://localhost:3000/api/anthropic/summarize?projectId={{projectId}}&taskId={{iterationTaskId}}&model=claude-3-5-haiku-20241022
 Content-Type: application/json
 Authorization: Bearer {{token}}


### PR DESCRIPTION
In dev mode, you can now enable logging of request and response bodies on an endpoint. Here's how to enable it for the `/api/profile` endpoint:

```sh
KOSO_SETTING_DEBUG_PATH="^/api/profile$" cargo run
```

Then, when you send a request, you'll see in your logs:

```
2025-07-03T02:37:04.182024Z DEBUG request{method=GET uri=/api/profile request_id="ef34bf0b-58fe-4d96-9090-822f567ac198"}: koso::debug: Request:
2025-07-03T02:37:04.185959Z DEBUG request{method=GET uri=/api/profile request_id="ef34bf0b-58fe-4d96-9090-822f567ac198"}: koso::debug: Response: {"notificationConfigs":[],"pluginConnections":{},"subscriptions":{"ownedSubscription":null,"endTime":"2100-01-20T13:00:00Z","status":"Active"}}
```