### PR TITLE
Migrates Goto component from kosui to local implementation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "js-base64": "3.7.7",
     "jsdom": "26.1.0",
     "jwt-decode": "4.0.0",
-    "kosui": "github:kosolabs/kosui#v0.0.2",
+    "kosui": "^0.0.7",
     "lib0": "0.2.114",
     "marked": "16.1.1",
     "mermaid": "11.9.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       kosui:
-        specifier: github:kosolabs/kosui#v0.0.2
-        version: https://codeload.github.com/kosolabs/kosui/tar.gz/6b7ff1a2ac1247b037cf456f19bb7124fbe4b037(svelte@5.37.1)
+        specifier: ^0.0.7
+        version: 0.0.7(svelte@5.37.1)
       lib0:
         specifier: 0.2.114
         version: 0.2.114
@@ -1737,9 +1737,8 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  kosui@https://codeload.github.com/kosolabs/kosui/tar.gz/6b7ff1a2ac1247b037cf456f19bb7124fbe4b037:
-    resolution: {tarball: https://codeload.github.com/kosolabs/kosui/tar.gz/6b7ff1a2ac1247b037cf456f19bb7124fbe4b037}
-    version: 0.0.2
+  kosui@0.0.7:
+    resolution: {integrity: sha512-A9nR+E49Dyt2pbd3GfCsC/27sxKz6RMh5u+y3m/7ZQF4YCQf0IKcxNDwGi8wysMbeCKqzSslOfAisvL+DCTCWw==}
     engines: {node: '>= 20'}
     peerDependencies:
       svelte: ^5.0.0
@@ -4284,7 +4283,7 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  kosui@https://codeload.github.com/kosolabs/kosui/tar.gz/6b7ff1a2ac1247b037cf456f19bb7124fbe4b037(svelte@5.37.1):
+  kosui@0.0.7(svelte@5.37.1):
     dependencies:
       svelte: 5.37.1
 

--- a/frontend/src/lib/components/ui/goto/goto.svelte
+++ b/frontend/src/lib/components/ui/goto/goto.svelte
@@ -1,0 +1,28 @@
+<script module lang="ts">
+  import { goto } from "$app/navigation";
+  import { Link, mergeProps, type LinkProps } from "kosui";
+  import type { Snippet } from "svelte";
+
+  export type GotoProps = {
+    href: string;
+    children: Snippet;
+  } & Omit<LinkProps, "href">;
+</script>
+
+<script lang="ts">
+  let { children, href, el = $bindable(), ...props }: GotoProps = $props();
+</script>
+
+<Link
+  bind:el
+  {...mergeProps(props, {
+    href,
+    onclick: (event: MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      goto(href);
+    },
+  })}
+>
+  {@render children?.()}
+</Link>

--- a/frontend/src/lib/components/ui/goto/index.ts
+++ b/frontend/src/lib/components/ui/goto/index.ts
@@ -1,0 +1,1 @@
+export { default as Goto, type GotoProps } from "./goto.svelte";

--- a/frontend/src/lib/components/ui/navbar/navigate-button.svelte
+++ b/frontend/src/lib/components/ui/navbar/navigate-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { Goto } from "$lib/components/ui/goto";
   import type { NavigationAction } from "$lib/navigation-action";
-  import { Goto } from "kosui";
   import { twMerge } from "tailwind-merge";
   import { getRegistryContext } from "../command-palette";
 

--- a/frontend/src/lib/dag-table/action-item-tooltip/action-item-tooltip.svelte
+++ b/frontend/src/lib/dag-table/action-item-tooltip/action-item-tooltip.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
+  import { Goto } from "$lib/components/ui/goto";
   import { Blocks, CalendarCheck2, CirclePlay, Icon } from "@lucide/svelte";
-  import { Button, Goto, Tooltip } from "kosui";
+  import { Button, Tooltip } from "kosui";
   import {
     type ActionItem,
     getInboxContext,

--- a/frontend/src/lib/dag-table/task-row.svelte
+++ b/frontend/src/lib/dag-table/task-row.svelte
@@ -3,6 +3,7 @@
   import { parseChipProps, type ChipProps } from "$lib/components/ui/chip";
   import { Editable } from "$lib/components/ui/editable";
   import { Estimate } from "$lib/components/ui/estimate";
+  import { Goto } from "$lib/components/ui/goto";
   import { ManagedTaskIcon } from "$lib/components/ui/managed-task-icon";
   import { getPrefsContext } from "$lib/components/ui/prefs";
   import { TaskStatus } from "$lib/components/ui/task-status";
@@ -10,7 +11,7 @@
   import type { User } from "$lib/users";
   import { cn } from "$lib/utils";
   import { Grip } from "@lucide/svelte";
-  import { Chip, Goto, Link } from "kosui";
+  import { Chip, Link } from "kosui";
   import { tick } from "svelte";
   import { ActionItemTooltip } from "./action-item-tooltip";
   import DescAction from "./desc-action.svelte";

--- a/frontend/src/routes/(auth)/projects/+page.svelte
+++ b/frontend/src/routes/(auth)/projects/+page.svelte
@@ -2,12 +2,13 @@
   import { goto } from "$app/navigation";
   import { KosoError } from "$lib/api";
   import { getAuthContext } from "$lib/auth.svelte";
+  import { Goto } from "$lib/components/ui/goto";
   import { Navbar } from "$lib/components/ui/navbar";
   import { toast } from "$lib/components/ui/sonner";
   import * as rest from "$lib/projects";
   import { type Project, type ProjectExport } from "$lib/projects";
   import { HardDriveUpload, Layers, PackagePlus, Trash2 } from "@lucide/svelte";
-  import { Alert, Button, Goto } from "kosui";
+  import { Alert, Button } from "kosui";
 
   const auth = getAuthContext();
 


### PR DESCRIPTION
Updates kosui dependency from GitHub source to published version 0.0.7 and creates local Goto component to replace the one previously imported from kosui.

The new local Goto component wraps kosui's Link with SvelteKit's goto navigation functionality, providing better integration with the application's routing system.
